### PR TITLE
feat: Enhance option handling in Paradex API

### DIFF
--- a/commons/paradex-common-api/src/main/java/com/fueledbychai/paradex/common/ParadexTickerRegistry.java
+++ b/commons/paradex-common-api/src/main/java/com/fueledbychai/paradex/common/ParadexTickerRegistry.java
@@ -1,14 +1,21 @@
 package com.fueledbychai.paradex.common;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Locale;
+
 import com.fueledbychai.data.Exchange;
 import com.fueledbychai.data.InstrumentType;
-import com.fueledbychai.data.TickerTranslator;
 import com.fueledbychai.paradex.common.api.IParadexRestApi;
 import com.fueledbychai.util.AbstractTickerRegistry;
 import com.fueledbychai.util.ExchangeRestApiFactory;
 import com.fueledbychai.util.ITickerRegistry;
 
 public class ParadexTickerRegistry extends AbstractTickerRegistry implements ITickerRegistry {
+
+    protected static final DateTimeFormatter COMMON_SYMBOL_OPTION_DATE = DateTimeFormatter.BASIC_ISO_DATE;
+    protected static final DateTimeFormatter PARADEX_OPTION_DATE = DateTimeFormatter.ofPattern("dMMMyy", Locale.US);
 
     protected static ITickerRegistry instace;
     protected IParadexRestApi restApi = ExchangeRestApiFactory.getPublicApi(Exchange.PARADEX, IParadexRestApi.class);
@@ -21,14 +28,14 @@ public class ParadexTickerRegistry extends AbstractTickerRegistry implements ITi
     }
 
     protected ParadexTickerRegistry() {
-        super(new TickerTranslator());
+        super(new ParadexTickerTranslator());
         initialize();
     }
 
     protected void initialize() {
         try {
-            registerDescriptors(restApi.getAllInstrumentsForTypes(
-                    new InstrumentType[] { InstrumentType.PERPETUAL_FUTURES, InstrumentType.CRYPTO_SPOT }));
+            registerDescriptors(restApi.getAllInstrumentsForTypes(new InstrumentType[] {
+                    InstrumentType.PERPETUAL_FUTURES, InstrumentType.CRYPTO_SPOT, InstrumentType.OPTION }));
         } catch (Exception e) {
             throw new RuntimeException("Failed to initialize ParadexTickerRegistry", e);
         }
@@ -36,17 +43,23 @@ public class ParadexTickerRegistry extends AbstractTickerRegistry implements ITi
 
     @Override
     protected boolean supportsInstrumentType(InstrumentType instrumentType) {
-        return instrumentType == InstrumentType.PERPETUAL_FUTURES || instrumentType == InstrumentType.CRYPTO_SPOT;
+        return instrumentType == InstrumentType.PERPETUAL_FUTURES || instrumentType == InstrumentType.CRYPTO_SPOT
+                || instrumentType == InstrumentType.OPTION;
     }
 
     @Override
     public String commonSymbolToExchangeSymbol(InstrumentType instrumentType, String commonSymbol) {
-        // common symbol is like BTC/USDT, exchange symbol is BTC-USD-PERP, if its
-        // BTC/USDC or BTC/USDT, then common symbol is BTC-USD-PERP
         requireSupportedInstrumentType(instrumentType);
         if (commonSymbol == null) {
             return null;
         }
+
+        if (instrumentType == InstrumentType.OPTION) {
+            return optionCommonSymbolToExchangeSymbol(commonSymbol);
+        }
+
+        // common symbol is like BTC/USDT, exchange symbol is BTC-USD-PERP, if its
+        // BTC/USDC or BTC/USDT, then common symbol is BTC-USD-PERP
         if (commonSymbol.endsWith("/USDC")) {
             commonSymbol = commonSymbol.substring(0, commonSymbol.length() - 5) + "/USD";
         } else if (commonSymbol.endsWith("/USDT")) {
@@ -57,5 +70,65 @@ public class ParadexTickerRegistry extends AbstractTickerRegistry implements ITi
             exchangeSymbol += "-PERP";
         }
         return exchangeSymbol;
+    }
+
+    /**
+     * Converts a Paradex option common-symbol-ish input into the canonical
+     * Paradex exchange symbol {@code BASE-QUOTE-DDMonYY-STRIKE-RIGHT} (e.g.
+     * {@code BTC-USD-26JUN26-67000-C}).
+     *
+     * <p>Two input forms are recognised:
+     * <ul>
+     *   <li>The structured common-symbol form produced by
+     *       {@code ParadexRestApi.parseInstrumentDescriptors} for OPTION
+     *       instruments: {@code BASE/QUOTE-YYYYMMDD-STRIKE-RIGHT} (e.g.
+     *       {@code BTC/USD-20260626-67000-C}).</li>
+     *   <li>A slash-separated mirror of the exchange symbol that some upstream
+     *       services use because '/' is more URL-/path-friendly:
+     *       {@code BASE/QUOTE/DDMonYY/STRIKE/RIGHT} (e.g.
+     *       {@code BTC/USD/26JUN26/67000/C}). This gets normalised by simply
+     *       replacing every '/' with '-'.</li>
+     * </ul>
+     * If the input is already in the exchange-symbol form (or is otherwise
+     * unparseable) the trimmed/upper-cased value is returned unchanged so the
+     * caller can fall through to a broker-symbol lookup.
+     */
+    protected String optionCommonSymbolToExchangeSymbol(String commonSymbol) {
+        String trimmed = commonSymbol.trim().toUpperCase(Locale.US);
+        int slashIndex = trimmed.indexOf('/');
+        if (slashIndex < 0 || slashIndex + 1 >= trimmed.length()) {
+            return trimmed;
+        }
+
+        // Slash-separated exchange symbol form (e.g. BTC/USD/26JUN26/67000/C):
+        // five segments separated by '/', with the third segment looking like
+        // a Paradex DDMonYY expiry token. Normalise by replacing '/' with '-'.
+        String[] slashParts = trimmed.split("/");
+        if (slashParts.length == 5 && slashParts[2].matches("\\d{1,2}[A-Z]{3}\\d{2}")) {
+            return trimmed.replace('/', '-');
+        }
+
+        // Structured common-symbol form (e.g. BTC/USD-20260626-67000-C):
+        // BASE / QUOTE - YYYYMMDD - STRIKE - RIGHT
+        String base = trimmed.substring(0, slashIndex);
+        String[] contractParts = trimmed.substring(slashIndex + 1).split("-");
+        if (contractParts.length != 4) {
+            return trimmed;
+        }
+
+        String quote = contractParts[0];
+        String expiryToken = contractParts[1];
+        String strike = contractParts[2];
+        String right = contractParts[3];
+
+        LocalDate expiry;
+        try {
+            expiry = LocalDate.parse(expiryToken, COMMON_SYMBOL_OPTION_DATE);
+        } catch (DateTimeParseException e) {
+            return trimmed;
+        }
+
+        String paradexExpiry = expiry.format(PARADEX_OPTION_DATE).toUpperCase(Locale.US);
+        return base + "-" + quote + "-" + paradexExpiry + "-" + strike + "-" + right;
     }
 }

--- a/commons/paradex-common-api/src/main/java/com/fueledbychai/paradex/common/ParadexTickerTranslator.java
+++ b/commons/paradex-common-api/src/main/java/com/fueledbychai/paradex/common/ParadexTickerTranslator.java
@@ -1,0 +1,89 @@
+package com.fueledbychai.paradex.common;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Locale;
+
+import com.fueledbychai.data.ITickerTranslator;
+import com.fueledbychai.data.InstrumentDescriptor;
+import com.fueledbychai.data.InstrumentType;
+import com.fueledbychai.data.Ticker;
+import com.fueledbychai.data.Ticker.Right;
+import com.fueledbychai.data.TickerTranslator;
+
+/**
+ * Translates {@link InstrumentDescriptor}s produced by the Paradex REST API
+ * into {@link Ticker}s, populating option-specific fields (strike, expiry,
+ * right) for OPTION instruments.
+ *
+ * <p>
+ * Paradex option common symbols are produced by
+ * {@code ParadexRestApi.parseInstrumentDescriptors} in the form
+ * {@code BASE/QUOTE-YYYYMMDD-STRIKE-RIGHT}, e.g. {@code BTC/USD-20260626-67000-C}.
+ * The exchange symbol uses Paradex's native format, e.g.
+ * {@code BTC-USD-26JUN26-67000-C}.
+ */
+public class ParadexTickerTranslator implements ITickerTranslator {
+
+    protected static final DateTimeFormatter COMMON_SYMBOL_OPTION_DATE = DateTimeFormatter.BASIC_ISO_DATE;
+    protected final TickerTranslator delegate = new TickerTranslator();
+
+    @Override
+    public Ticker translateTicker(InstrumentDescriptor descriptor) {
+        Ticker ticker = delegate.translateTicker(descriptor);
+        if (descriptor == null || descriptor.getInstrumentType() != InstrumentType.OPTION) {
+            return ticker;
+        }
+
+        String commonSymbol = descriptor.getCommonSymbol();
+        if (commonSymbol == null || commonSymbol.isBlank()) {
+            return ticker;
+        }
+
+        String normalized = commonSymbol.trim().toUpperCase(Locale.US);
+        int slashIndex = normalized.indexOf('/');
+        if (slashIndex < 0 || slashIndex + 1 >= normalized.length()) {
+            return ticker;
+        }
+
+        String[] contractParts = normalized.substring(slashIndex + 1).split("-");
+        // Expected: QUOTE-YYYYMMDD-STRIKE-RIGHT, length 4
+        if (contractParts.length != 4) {
+            return ticker;
+        }
+
+        LocalDate expiry = parseExpiry(contractParts[1]);
+        if (expiry != null) {
+            ticker.setExpiryYear(expiry.getYear());
+            ticker.setExpiryMonth(expiry.getMonthValue());
+            ticker.setExpiryDay(expiry.getDayOfMonth());
+        }
+
+        try {
+            ticker.setStrike(new BigDecimal(contractParts[2]));
+        } catch (NumberFormatException ignored) {
+            // Leave strike unset when malformed.
+        }
+
+        if ("C".equals(contractParts[3])) {
+            ticker.setRight(Right.CALL);
+        } else if ("P".equals(contractParts[3])) {
+            ticker.setRight(Right.PUT);
+        }
+
+        return ticker;
+    }
+
+    protected LocalDate parseExpiry(String expiryToken) {
+        if (expiryToken == null || expiryToken.length() != 8) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(expiryToken, COMMON_SYMBOL_OPTION_DATE);
+        } catch (DateTimeParseException ignored) {
+            return null;
+        }
+    }
+}

--- a/commons/paradex-common-api/src/main/java/com/fueledbychai/paradex/common/api/ParadexRestApi.java
+++ b/commons/paradex-common-api/src/main/java/com/fueledbychai/paradex/common/api/ParadexRestApi.java
@@ -6,13 +6,17 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Proxy;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.json.JSONObject;
@@ -229,8 +233,7 @@ public class ParadexRestApi extends BaseRestApi implements IParadexRestApi {
         if (market == null || market.isBlank()) {
             throw new IllegalArgumentException("market is required");
         }
-        String path = "/bbo/" + market.trim();
-        String newUrl = baseUrl + path;
+        String newUrl = buildBBOUrl(market.trim());
 
         Request request = new Request.Builder().url(newUrl).get().build();
         logger.info("Request: " + request);
@@ -251,6 +254,23 @@ public class ParadexRestApi extends BaseRestApi implements IParadexRestApi {
             logger.error(e.getMessage(), e);
             throw new ResponseException("Network error getting Paradex BBO: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * Builds the BBO request URL for the given market. Uses
+     * {@link HttpUrl.Builder#addPathSegment(String)} so the market is always
+     * treated as a single, properly-encoded path segment. Without this, a
+     * slash in the market value (e.g. a common-symbol form like
+     * {@code BTC/USD-20260626-67000-C}) would split the URL into extra path
+     * segments and Paradex would route the request to a different
+     * (auth-protected) handler, returning a misleading 401 INVALID_TOKEN error.
+     */
+    protected String buildBBOUrl(String market) {
+        HttpUrl base = HttpUrl.parse(baseUrl + "/bbo");
+        if (base == null) {
+            throw new ResponseException("Invalid baseUrl for Paradex BBO request: " + baseUrl, 0);
+        }
+        return base.newBuilder().addPathSegment(market).build().toString();
     }
 
     @Override
@@ -1240,8 +1260,20 @@ public class ParadexRestApi extends BaseRestApi implements IParadexRestApi {
                 String baseCurrency = instrumentObj.get("base_currency").getAsString();
                 String quoteCurrency = instrumentObj.get("quote_currency").getAsString();
 
-                // Create common symbol (without exchange-specific suffix)
-                String commonSymbol = symbol.split("-")[0];
+                // Create common symbol. For OPTION instruments we encode the
+                // strike, expiry, and right into the common symbol so the
+                // ParadexTickerTranslator can decode them. For everything else
+                // we strip the exchange-specific suffix.
+                String commonSymbol;
+                if (instrumentType == InstrumentType.OPTION) {
+                    commonSymbol = buildOptionCommonSymbol(instrumentObj, baseCurrency, quoteCurrency);
+                    if (commonSymbol == null) {
+                        logger.warn("Skipping option instrument '{}' due to missing/invalid option metadata", symbol);
+                        continue;
+                    }
+                } else {
+                    commonSymbol = symbol.split("-")[0];
+                }
                 String exchangeSymbol = symbol;
 
                 // Parse tick size and order size increment from the JSON
@@ -1266,6 +1298,65 @@ public class ParadexRestApi extends BaseRestApi implements IParadexRestApi {
             logger.error("Error parsing instrument descriptors: " + e.getMessage(), e);
             throw new FueledByChaiException(e);
         }
+    }
+
+    /**
+     * Builds a structured common symbol for an option instrument in the form
+     * {@code BASE/QUOTE-YYYYMMDD-STRIKE-RIGHT}, e.g.
+     * {@code BTC/USD-20260626-67000-C}. The {@link ParadexTickerTranslator}
+     * decodes this format to populate the option-specific fields on the
+     * resulting {@link Ticker}.
+     *
+     * @return the encoded common symbol, or {@code null} if any required
+     *         option metadata is missing or invalid.
+     */
+    protected String buildOptionCommonSymbol(JsonObject instrumentObj, String baseCurrency, String quoteCurrency) {
+        if (baseCurrency == null || quoteCurrency == null) {
+            return null;
+        }
+        if (!instrumentObj.has("option_type") || instrumentObj.get("option_type").isJsonNull()) {
+            return null;
+        }
+        if (!instrumentObj.has("strike_price") || instrumentObj.get("strike_price").isJsonNull()) {
+            return null;
+        }
+        if (!instrumentObj.has("expiry_at") || instrumentObj.get("expiry_at").isJsonNull()) {
+            return null;
+        }
+
+        String optionType = instrumentObj.get("option_type").getAsString();
+        String rightLetter;
+        if ("CALL".equalsIgnoreCase(optionType)) {
+            rightLetter = "C";
+        } else if ("PUT".equalsIgnoreCase(optionType)) {
+            rightLetter = "P";
+        } else {
+            return null;
+        }
+
+        String strikePrice;
+        try {
+            strikePrice = new BigDecimal(instrumentObj.get("strike_price").getAsString()).stripTrailingZeros()
+                    .toPlainString();
+        } catch (NumberFormatException e) {
+            return null;
+        }
+
+        long expiryMillis;
+        try {
+            expiryMillis = instrumentObj.get("expiry_at").getAsLong();
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        if (expiryMillis <= 0L) {
+            return null;
+        }
+
+        LocalDate expiryDate = Instant.ofEpochMilli(expiryMillis).atZone(ZoneOffset.UTC).toLocalDate();
+        String expiryToken = String.format(Locale.US, "%04d%02d%02d", expiryDate.getYear(), expiryDate.getMonthValue(),
+                expiryDate.getDayOfMonth());
+
+        return baseCurrency + "/" + quoteCurrency + "-" + expiryToken + "-" + strikePrice + "-" + rightLetter;
     }
 
     /**

--- a/commons/paradex-common-api/src/test/java/com/fueledbychai/paradex/common/ParadexTickerRegistryTest.java
+++ b/commons/paradex-common-api/src/test/java/com/fueledbychai/paradex/common/ParadexTickerRegistryTest.java
@@ -105,6 +105,33 @@ public class ParadexTickerRegistryTest {
     }
 
     @Test
+    public void testCommonSymbolToExchangeSymbol_OptionStructuredCommonSymbol() {
+        // Common-symbol form produced by parseInstrumentDescriptors:
+        // BASE/QUOTE-YYYYMMDD-STRIKE-RIGHT
+        String result = tickerRegistry.commonSymbolToExchangeSymbol(InstrumentType.OPTION,
+                "BTC/USD-20260626-67000-C");
+        assertEquals("BTC-USD-26JUN26-67000-C", result);
+    }
+
+    @Test
+    public void testCommonSymbolToExchangeSymbol_OptionSlashSeparatedExchangeSymbol() {
+        // Slash-separated mirror of the exchange symbol
+        // (BASE/QUOTE/DDMonYY/STRIKE/RIGHT). This is the form some upstream
+        // services pass because '/' is more URL-/path-friendly. The registry
+        // should normalise it back to the proper Paradex exchange symbol.
+        String result = tickerRegistry.commonSymbolToExchangeSymbol(InstrumentType.OPTION,
+                "BTC/USD/24APR26/75000/C");
+        assertEquals("BTC-USD-24APR26-75000-C", result);
+    }
+
+    @Test
+    public void testCommonSymbolToExchangeSymbol_OptionSlashSeparatedSingleDigitDay() {
+        String result = tickerRegistry.commonSymbolToExchangeSymbol(InstrumentType.OPTION,
+                "BTC/USD/9APR26/69000/P");
+        assertEquals("BTC-USD-9APR26-69000-P", result);
+    }
+
+    @Test
     public void testInitializeRegistersPerpAndSpotDescriptors() {
         InstrumentDescriptor perpDescriptor = new InstrumentDescriptor(InstrumentType.PERPETUAL_FUTURES,
                 Exchange.PARADEX, "BTC", "BTC-USD-PERP", "BTC", "USD", new BigDecimal("0.001"), new BigDecimal("0.1"),

--- a/commons/paradex-common-api/src/test/java/com/fueledbychai/paradex/common/ParadexTickerTranslatorTest.java
+++ b/commons/paradex-common-api/src/test/java/com/fueledbychai/paradex/common/ParadexTickerTranslatorTest.java
@@ -1,0 +1,93 @@
+package com.fueledbychai.paradex.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fueledbychai.data.Exchange;
+import com.fueledbychai.data.InstrumentDescriptor;
+import com.fueledbychai.data.InstrumentType;
+import com.fueledbychai.data.Ticker;
+import com.fueledbychai.data.Ticker.Right;
+
+class ParadexTickerTranslatorTest {
+
+    private ParadexTickerTranslator translator;
+
+    @BeforeEach
+    void setUp() {
+        translator = new ParadexTickerTranslator();
+    }
+
+    @Test
+    void testTranslateOptionCall() {
+        InstrumentDescriptor descriptor = new InstrumentDescriptor(InstrumentType.OPTION, Exchange.PARADEX,
+                "BTC/USD-20260626-67000-C", "BTC-USD-26JUN26-67000-C", "BTC", "USD", new BigDecimal("0.001"),
+                new BigDecimal("0.01"), 20, BigDecimal.ZERO, 0, BigDecimal.ONE, 1, "");
+
+        Ticker ticker = translator.translateTicker(descriptor);
+
+        assertNotNull(ticker);
+        assertEquals("BTC-USD-26JUN26-67000-C", ticker.getSymbol());
+        assertEquals(InstrumentType.OPTION, ticker.getInstrumentType());
+        assertEquals(2026, ticker.getExpiryYear());
+        assertEquals(6, ticker.getExpiryMonth());
+        assertEquals(26, ticker.getExpiryDay());
+        assertEquals(new BigDecimal("67000"), ticker.getStrike());
+        assertEquals(Right.CALL, ticker.getRight());
+    }
+
+    @Test
+    void testTranslateOptionPut() {
+        InstrumentDescriptor descriptor = new InstrumentDescriptor(InstrumentType.OPTION, Exchange.PARADEX,
+                "ETH/USD-20260101-3500-P", "ETH-USD-1JAN26-3500-P", "ETH", "USD", new BigDecimal("0.001"),
+                new BigDecimal("0.01"), 20, BigDecimal.ZERO, 0, BigDecimal.ONE, 1, "");
+
+        Ticker ticker = translator.translateTicker(descriptor);
+
+        assertEquals(2026, ticker.getExpiryYear());
+        assertEquals(1, ticker.getExpiryMonth());
+        assertEquals(1, ticker.getExpiryDay());
+        assertEquals(new BigDecimal("3500"), ticker.getStrike());
+        assertEquals(Right.PUT, ticker.getRight());
+    }
+
+    @Test
+    void testTranslateNonOptionLeavesOptionFieldsUnset() {
+        InstrumentDescriptor descriptor = new InstrumentDescriptor(InstrumentType.PERPETUAL_FUTURES, Exchange.PARADEX,
+                "BTC", "BTC-USD-PERP", "BTC", "USD", new BigDecimal("0.00001"), new BigDecimal("0.1"), 100,
+                BigDecimal.ZERO, 8, BigDecimal.ONE, 50, "");
+
+        Ticker ticker = translator.translateTicker(descriptor);
+
+        assertNotNull(ticker);
+        assertEquals(InstrumentType.PERPETUAL_FUTURES, ticker.getInstrumentType());
+        assertEquals(0, ticker.getExpiryYear());
+        assertEquals(0, ticker.getExpiryMonth());
+        assertEquals(0, ticker.getExpiryDay());
+        assertNull(ticker.getStrike());
+        assertEquals(Right.NONE, ticker.getRight());
+    }
+
+    @Test
+    void testTranslateOptionMalformedSymbolFallsBackGracefully() {
+        // Common symbol does not encode option metadata - translator should
+        // not blow up; it just leaves option fields unset.
+        InstrumentDescriptor descriptor = new InstrumentDescriptor(InstrumentType.OPTION, Exchange.PARADEX,
+                "BTC", "BTC-USD-26JUN26-67000-C", "BTC", "USD", new BigDecimal("0.001"), new BigDecimal("0.01"), 20,
+                BigDecimal.ZERO, 0, BigDecimal.ONE, 1, "");
+
+        Ticker ticker = translator.translateTicker(descriptor);
+
+        assertNotNull(ticker);
+        assertEquals(InstrumentType.OPTION, ticker.getInstrumentType());
+        assertEquals(0, ticker.getExpiryYear());
+        assertNull(ticker.getStrike());
+        assertEquals(Right.NONE, ticker.getRight());
+    }
+}

--- a/commons/paradex-common-api/src/test/java/com/fueledbychai/paradex/common/api/ParadexRestApiTest.java
+++ b/commons/paradex-common-api/src/test/java/com/fueledbychai/paradex/common/api/ParadexRestApiTest.java
@@ -471,6 +471,113 @@ class ParadexRestApiTest {
         });
     }
 
+    @Test
+    void testParseInstrumentDescriptors_Option() {
+        // Given - Real Paradex option response shape (BTC-USD-26JUN26-67000-C)
+        // expiry_at = 1782460800000 → 2026-06-26 UTC
+        String optionJson = "{\n" + "    \"results\": [\n" + "        {\n"
+                + "            \"symbol\": \"BTC-USD-26JUN26-67000-C\",\n"
+                + "            \"base_currency\": \"BTC\",\n" + "            \"quote_currency\": \"USD\",\n"
+                + "            \"settlement_currency\": \"USDC\",\n"
+                + "            \"order_size_increment\": \"0.001\",\n"
+                + "            \"price_tick_size\": \"0.01\",\n" + "            \"min_notional\": \"20\",\n"
+                + "            \"expiry_at\": 1782460800000,\n" + "            \"asset_kind\": \"OPTION\",\n"
+                + "            \"option_type\": \"CALL\",\n" + "            \"strike_price\": \"67000\",\n"
+                + "            \"funding_period_hours\": 0\n" + "        }\n" + "    ]\n" + "}";
+
+        // When
+        InstrumentDescriptor[] result = paradexRestApi.parseInstrumentDescriptors(InstrumentType.OPTION, optionJson);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.length);
+        InstrumentDescriptor descriptor = result[0];
+        assertEquals(InstrumentType.OPTION, descriptor.getInstrumentType());
+        assertEquals(Exchange.PARADEX, descriptor.getExchange());
+        assertEquals("BTC-USD-26JUN26-67000-C", descriptor.getExchangeSymbol());
+        // Common symbol encodes strike, expiry, right so the translator can decode it.
+        assertEquals("BTC/USD-20260626-67000-C", descriptor.getCommonSymbol());
+        assertEquals("BTC", descriptor.getBaseCurrency());
+        assertEquals("USD", descriptor.getQuoteCurrency());
+        assertEquals(new BigDecimal("0.001"), descriptor.getOrderSizeIncrement());
+        assertEquals(new BigDecimal("0.01"), descriptor.getPriceTickSize());
+    }
+
+    @Test
+    void testParseInstrumentDescriptors_OptionPut() {
+        // expiry_at = 1782460800000 → 2026-06-26 UTC
+        String optionJson = "{\n" + "    \"results\": [\n" + "        {\n"
+                + "            \"symbol\": \"BTC-USD-26JUN26-67000-P\",\n"
+                + "            \"base_currency\": \"BTC\",\n" + "            \"quote_currency\": \"USD\",\n"
+                + "            \"order_size_increment\": \"0.001\",\n"
+                + "            \"price_tick_size\": \"0.01\",\n" + "            \"min_notional\": \"20\",\n"
+                + "            \"expiry_at\": 1782460800000,\n" + "            \"asset_kind\": \"OPTION\",\n"
+                + "            \"option_type\": \"PUT\",\n" + "            \"strike_price\": \"67000.00\",\n"
+                + "            \"funding_period_hours\": 0\n" + "        }\n" + "    ]\n" + "}";
+
+        InstrumentDescriptor[] result = paradexRestApi.parseInstrumentDescriptors(InstrumentType.OPTION, optionJson);
+
+        assertNotNull(result);
+        assertEquals(1, result.length);
+        // Strike is normalized via stripTrailingZeros() so 67000.00 → 67000
+        assertEquals("BTC/USD-20260626-67000-P", result[0].getCommonSymbol());
+    }
+
+    // ============= Tests for getBBO URL building =============
+
+    @Test
+    void testBuildBBOUrl_PerpExchangeSymbol() {
+        String url = paradexRestApi.buildBBOUrl("BTC-USD-PERP");
+        assertEquals("https://api.testnet.paradex.trade/v1/bbo/BTC-USD-PERP", url);
+    }
+
+    @Test
+    void testBuildBBOUrl_OptionExchangeSymbol() {
+        String url = paradexRestApi.buildBBOUrl("BTC-USD-26JUN26-67000-C");
+        assertEquals("https://api.testnet.paradex.trade/v1/bbo/BTC-USD-26JUN26-67000-C", url);
+    }
+
+    @Test
+    void testBuildBBOUrl_EncodesSlashInMarket() {
+        // A slash in the market must be percent-encoded so it doesn't split
+        // the path and trigger Paradex's auth-protected /bbo handler.
+        String url = paradexRestApi.buildBBOUrl("BTC/USD");
+        assertEquals("https://api.testnet.paradex.trade/v1/bbo/BTC%2FUSD", url);
+    }
+
+    @Test
+    void testBuildBBOUrl_EncodesSlashInOptionCommonSymbol() {
+        String url = paradexRestApi.buildBBOUrl("BTC/USD-20260626-67000-C");
+        assertEquals("https://api.testnet.paradex.trade/v1/bbo/BTC%2FUSD-20260626-67000-C", url);
+    }
+
+    @Test
+    void testGetBBO_RejectsBlankMarket() {
+        assertThrows(IllegalArgumentException.class, () -> paradexRestApi.getBBO(""));
+        assertThrows(IllegalArgumentException.class, () -> paradexRestApi.getBBO("   "));
+        assertThrows(IllegalArgumentException.class, () -> paradexRestApi.getBBO(null));
+    }
+
+    @Test
+    void testParseInstrumentDescriptors_OptionMissingExpiry() {
+        // Given - Option JSON missing expiry_at
+        String optionJson = "{\n" + "    \"results\": [\n" + "        {\n"
+                + "            \"symbol\": \"BTC-USD-26JUN26-67000-C\",\n"
+                + "            \"base_currency\": \"BTC\",\n" + "            \"quote_currency\": \"USD\",\n"
+                + "            \"order_size_increment\": \"0.001\",\n"
+                + "            \"price_tick_size\": \"0.01\",\n" + "            \"min_notional\": \"20\",\n"
+                + "            \"asset_kind\": \"OPTION\",\n" + "            \"option_type\": \"CALL\",\n"
+                + "            \"strike_price\": \"67000\",\n" + "            \"funding_period_hours\": 0\n"
+                + "        }\n" + "    ]\n" + "}";
+
+        // When - Missing option metadata should cause the option to be skipped
+        InstrumentDescriptor[] result = paradexRestApi.parseInstrumentDescriptors(InstrumentType.OPTION, optionJson);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(0, result.length);
+    }
+
     // ============= Tests for isValidAssetKindForInstrumentType method
     // =============
 

--- a/docs/generated/README.md
+++ b/docs/generated/README.md
@@ -49,4 +49,4 @@ java -cp "target/classes:target/dependency/*" \
 ```
 
 ---
-*Generated on: 2026-04-06T12:03:40.759759*
+*Generated on: 2026-04-07T13:35:06.244409*

--- a/implementations/broker-api/paper-broker-api-impl/src/main/java/com/fueledbychai/broker/paper/MultiTickerPaperBroker.java
+++ b/implementations/broker-api/paper-broker-api-impl/src/main/java/com/fueledbychai/broker/paper/MultiTickerPaperBroker.java
@@ -389,7 +389,7 @@ public class MultiTickerPaperBroker extends AbstractBasicBroker implements Level
     public BrokerRequestResult placeOrder(OrderTicket order) {
         order.setOrderEntryTime(getCurrentTime());
         delayRestCall();
-        String orderId = System.currentTimeMillis() + "-" + (int) (Math.random() * 10000);
+        String orderId = UUID.randomUUID().toString();
         order.setOrderId(orderId);
 
         Ticker ticker = order.getTicker();
@@ -742,7 +742,7 @@ public class MultiTickerPaperBroker extends AbstractBasicBroker implements Level
 
             fill = new Fill();
             fill.setCommission(BigDecimal.valueOf(fee));
-            fill.setFillId(System.currentTimeMillis() + "-" + (int) (Math.random() * 10000));
+            fill.setFillId(UUID.randomUUID().toString());
             fill.setOrderId(orderId);
             fill.setClientOrderId(fillableOrder.getClientOrderId());
             fill.setPrice(averageFillPrice);
@@ -1190,11 +1190,16 @@ public class MultiTickerPaperBroker extends AbstractBasicBroker implements Level
         if (outputDir == null || outputDir.isBlank()) {
             return filename;
         }
-        File dir = new File(outputDir);
-        if (!dir.exists()) {
-            dir.mkdirs();
+        java.nio.file.Path outputPath = Paths.get(outputDir);
+        if (Files.exists(outputPath) && !Files.isDirectory(outputPath)) {
+            throw new IllegalStateException("Output path exists but is not a directory: " + outputDir);
         }
-        return Paths.get(outputDir, filename).toString();
+        try {
+            Files.createDirectories(outputPath);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to create output directory: " + outputDir, e);
+        }
+        return outputPath.resolve(filename).toString();
     }
 
     protected String sanitizeFilenameComponent(String value) {

--- a/implementations/market-data-api/paradex-market-data-impl/src/main/java/com/fueledbychai/marketdata/paradex/ParadexQuoteEngine.java
+++ b/implementations/market-data-api/paradex-market-data-impl/src/main/java/com/fueledbychai/marketdata/paradex/ParadexQuoteEngine.java
@@ -109,30 +109,70 @@ public class ParadexQuoteEngine extends QuoteEngine
         if (ticker == null) {
             throw new IllegalArgumentException("ticker is required");
         }
-        String market = ticker.getSymbol();
-        JsonObject response = restApi.getBBO(market);
+        Ticker canonical = canonicalize(ticker);
+        JsonObject response = restApi.getBBO(canonical.getSymbol());
         if (response == null) {
-            throw new IllegalStateException("No BBO data returned for " + market);
+            throw new IllegalStateException("No BBO data returned for " + canonical.getSymbol());
         }
         ZonedDateTime now = ZonedDateTime.now(ZoneId.of("UTC"));
-        Level1Quote quote = new Level1Quote(ticker, now);
+        Level1Quote quote = new Level1Quote(canonical, now);
         BigDecimal bidPrice = getBigDecimalField(response, "bid");
         BigDecimal bidSize = getBigDecimalField(response, "bid_size");
         BigDecimal askPrice = getBigDecimalField(response, "ask");
         BigDecimal askSize = getBigDecimalField(response, "ask_size");
         if (bidPrice != null) {
-            quote.addQuote(QuoteType.BID, ticker.formatPrice(bidPrice));
+            quote.addQuote(QuoteType.BID, canonical.formatPrice(bidPrice));
         }
         if (bidSize != null) {
             quote.addQuote(QuoteType.BID_SIZE, bidSize);
         }
         if (askPrice != null) {
-            quote.addQuote(QuoteType.ASK, ticker.formatPrice(askPrice));
+            quote.addQuote(QuoteType.ASK, canonical.formatPrice(askPrice));
         }
         if (askSize != null) {
             quote.addQuote(QuoteType.ASK_SIZE, askSize);
         }
         return quote;
+    }
+
+    /**
+     * Returns the canonical {@link Ticker} for the given input by resolving it
+     * through the ticker registry. If the input ticker's symbol already
+     * matches a registered Paradex exchange symbol it is returned as-is;
+     * otherwise the registry is consulted (first by broker symbol, then by
+     * common symbol) to find the canonical Ticker. This protects callers that
+     * hand the engine tickers built from user-friendly forms — e.g. an option
+     * carrying {@code BTC/USD/24APR26/75000/C} or {@code BTC/USD-20260424-75000-C}
+     * instead of Paradex's {@code BTC-USD-24APR26-75000-C} — by returning the
+     * registry-cached canonical Ticker so all downstream calls (REST URLs,
+     * WebSocket channel names, OrderBookRegistry keys) use a consistent symbol.
+     * If lookup fails the original ticker is returned unchanged.
+     */
+    protected Ticker canonicalize(Ticker ticker) {
+        if (ticker == null) {
+            return null;
+        }
+        String symbol = ticker.getSymbol();
+        if (symbol == null) {
+            return ticker;
+        }
+        InstrumentType instrumentType = ticker.getInstrumentType();
+        if (instrumentType == null) {
+            return ticker;
+        }
+        // Fast path: a symbol that already matches a registered broker symbol
+        // (no slash in it, in practice) maps directly to its cached Ticker.
+        Ticker direct = tickerRegistry.lookupByBrokerSymbol(instrumentType, symbol);
+        if (direct != null) {
+            return direct;
+        }
+        // Otherwise treat the input as a common-symbol form and let the
+        // registry's commonSymbolToExchangeSymbol logic translate it.
+        Ticker viaCommon = tickerRegistry.lookupByCommonSymbol(instrumentType, symbol);
+        if (viaCommon != null) {
+            return viaCommon;
+        }
+        return ticker;
     }
 
     protected BigDecimal getBigDecimalField(JsonObject object, String key) {
@@ -148,34 +188,52 @@ public class ParadexQuoteEngine extends QuoteEngine
 
     @Override
     public void subscribeMarketDepth(Ticker ticker, Level2QuoteListener listener) {
-        logger.debug("Subscribing to market depth for ticker: {} Listener: {}", ticker.getSymbol(), listener);
-        super.subscribeMarketDepth(ticker, listener);
-        OrderBookRegistry.getInstance().getOrderBook(ticker).addOrderBookUpdateListener(this);
+        Ticker canonical = canonicalize(ticker);
+        logger.debug("Subscribing to market depth for ticker: {} Listener: {}", canonical.getSymbol(), listener);
+        super.subscribeMarketDepth(canonical, listener);
+        OrderBookRegistry.getInstance().getOrderBook(canonical).addOrderBookUpdateListener(this);
+    }
+
+    @Override
+    public void unsubscribeMarketDepth(Ticker ticker, Level2QuoteListener listener) {
+        super.unsubscribeMarketDepth(canonicalize(ticker), listener);
     }
 
     @Override
     public void subscribeLevel1(Ticker ticker, Level1QuoteListener listener) {
-        super.subscribeLevel1(ticker, listener);
-        OrderBookRegistry.getInstance().getOrderBook(ticker).addOrderBookUpdateListener(this);
-        MarketsSummaryWebSocketClient marketsSummaryClient = marketsSummaryClients.get(ticker);
+        Ticker canonical = canonicalize(ticker);
+        super.subscribeLevel1(canonical, listener);
+        OrderBookRegistry.getInstance().getOrderBook(canonical).addOrderBookUpdateListener(this);
+        MarketsSummaryWebSocketClient marketsSummaryClient = marketsSummaryClients.get(canonical);
         if (marketsSummaryClient == null) {
             marketsSummaryClient = new MarketsSummaryWebSocketClient();
-            marketsSummaryClients.put(ticker, marketsSummaryClient);
-            marketsSummaryClient.startMarketsSummaryWSClient(ticker, this);
+            marketsSummaryClients.put(canonical, marketsSummaryClient);
+            marketsSummaryClient.startMarketsSummaryWSClient(canonical, this);
         }
 
     }
 
     @Override
+    public void unsubscribeLevel1(Ticker ticker, Level1QuoteListener listener) {
+        super.unsubscribeLevel1(canonicalize(ticker), listener);
+    }
+
+    @Override
     public void subscribeOrderFlow(Ticker ticker, OrderFlowListener listener) {
-        super.subscribeOrderFlow(ticker, listener);
-        TradesWebSocketClient tradesClient = tradesClients.get(ticker);
+        Ticker canonical = canonicalize(ticker);
+        super.subscribeOrderFlow(canonical, listener);
+        TradesWebSocketClient tradesClient = tradesClients.get(canonical);
         if (tradesClient == null) {
             tradesClient = new TradesWebSocketClient();
-            tradesClients.put(ticker, tradesClient);
-            tradesClient.startTradesWSClient(ticker, this);
+            tradesClients.put(canonical, tradesClient);
+            tradesClient.startTradesWSClient(canonical, this);
         }
 
+    }
+
+    @Override
+    public void unsubscribeOrderFlow(Ticker ticker, OrderFlowListener listener) {
+        super.unsubscribeOrderFlow(canonicalize(ticker), listener);
     }
 
     @Override
@@ -220,10 +278,20 @@ public class ParadexQuoteEngine extends QuoteEngine
             return;
         }
 
-        // Format the price according to the ticker's minimum tick size precision
-        BigDecimal formattedPrice = ticker.formatPrice(price);
+        BigDecimal sizeDecimal = parseBigDecimal(size);
+        if (sizeDecimal == null) {
+            logger.debug("Skipping trade update for '{}' with missing/blank size", market);
+            return;
+        }
 
-        OrderFlow orderFlow = new OrderFlow(ticker, formattedPrice, new BigDecimal(size), OrderFlow.Side.valueOf(side),
+        // Format the price according to the ticker's minimum tick size precision
+        BigDecimal formattedPrice = ticker.formatPrice(parseBigDecimal(price));
+        if (formattedPrice == null) {
+            logger.debug("Skipping trade update for '{}' with missing/blank price", market);
+            return;
+        }
+
+        OrderFlow orderFlow = new OrderFlow(ticker, formattedPrice, sizeDecimal, OrderFlow.Side.valueOf(side),
                 convertToZonedDateTime(createdAtTimestamp));
         super.fireOrderFlow(orderFlow);
     }
@@ -238,32 +306,68 @@ public class ParadexQuoteEngine extends QuoteEngine
             return;
         }
 
-        BigDecimal volumeNotional = ticker.formatPrice(lastPrice).multiply(new BigDecimal(volume24h));
-        BigDecimal openInterestBigDecimal = new BigDecimal(openInterest);
-        BigDecimal openInterestNotional = ticker.formatPrice(lastPrice).multiply(openInterestBigDecimal);
+        // Paradex sends empty strings for fields that have no value yet
+        // (common for newly-listed options without trading activity). Parse
+        // each field defensively and only populate the corresponding quote
+        // entry when we actually have a number.
+        BigDecimal lastPriceDecimal = ticker.formatPrice(parseBigDecimal(lastPrice));
+        BigDecimal markPriceDecimal = ticker.formatPrice(parseBigDecimal(markPrice));
+        BigDecimal openInterestDecimal = parseBigDecimal(openInterest);
+        BigDecimal volume24hDecimal = parseBigDecimal(volume24h);
+        BigDecimal underlyingPriceDecimal = ticker.formatPrice(parseBigDecimal(underlyingPrice));
 
         // The bid and the ask from this market summary websocket aren't reliably
-        // upddated, better to use thee
-        // top of the order book.
+        // updated, better to use the top of the order book.
         Map<QuoteType, BigDecimal> quoteValues = new HashMap<>();
-        quoteValues.put(QuoteType.LAST, ticker.formatPrice(lastPrice));
-        quoteValues.put(QuoteType.MARK_PRICE, ticker.formatPrice(markPrice));
-        quoteValues.put(QuoteType.OPEN_INTEREST, new BigDecimal(openInterest));
-        quoteValues.put(QuoteType.VOLUME, new BigDecimal(volume24h));
-        quoteValues.put(QuoteType.OPEN_INTEREST, openInterestBigDecimal);
-        quoteValues.put(QuoteType.OPEN_INTEREST_NOTIONAL, openInterestNotional);
-        quoteValues.put(QuoteType.VOLUME_NOTIONAL, volumeNotional);
-        quoteValues.put(QuoteType.UNDERLYING_PRICE, ticker.formatPrice(underlyingPrice));
+        putIfNotNull(quoteValues, QuoteType.LAST, lastPriceDecimal);
+        putIfNotNull(quoteValues, QuoteType.MARK_PRICE, markPriceDecimal);
+        putIfNotNull(quoteValues, QuoteType.OPEN_INTEREST, openInterestDecimal);
+        putIfNotNull(quoteValues, QuoteType.VOLUME, volume24hDecimal);
+        putIfNotNull(quoteValues, QuoteType.UNDERLYING_PRICE, underlyingPriceDecimal);
+        if (lastPriceDecimal != null && volume24hDecimal != null) {
+            quoteValues.put(QuoteType.VOLUME_NOTIONAL, lastPriceDecimal.multiply(volume24hDecimal));
+        }
+        if (lastPriceDecimal != null && openInterestDecimal != null) {
+            quoteValues.put(QuoteType.OPEN_INTEREST_NOTIONAL, lastPriceDecimal.multiply(openInterestDecimal));
+        }
         addFundingRateQuotes(ticker, fundingRate, quoteValues);
 
         ILevel1Quote quote = new Level1Quote(ticker, convertToZonedDateTime(createdAtTimestamp), quoteValues);
         super.fireLevel1Quote(quote);
     }
 
+    /**
+     * Parses a possibly blank/null string into a {@link BigDecimal}, returning
+     * {@code null} for blank inputs and unparseable values. Paradex's WebSocket
+     * feeds send empty strings for fields with no value yet (common for
+     * newly-listed options without activity), so callers must guard against
+     * these instead of letting them throw {@link NumberFormatException}.
+     */
+    protected BigDecimal parseBigDecimal(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return new BigDecimal(value);
+        } catch (NumberFormatException e) {
+            logger.debug("Could not parse BigDecimal from value '{}'", value);
+            return null;
+        }
+    }
+
+    private static void putIfNotNull(Map<QuoteType, BigDecimal> map, QuoteType key, BigDecimal value) {
+        if (value != null) {
+            map.put(key, value);
+        }
+    }
+
     protected Ticker resolveTicker(String symbol) {
         Ticker ticker = tickerRegistry.lookupByBrokerSymbol(InstrumentType.PERPETUAL_FUTURES, symbol);
         if (ticker == null) {
             ticker = tickerRegistry.lookupByBrokerSymbol(InstrumentType.CRYPTO_SPOT, symbol);
+        }
+        if (ticker == null) {
+            ticker = tickerRegistry.lookupByBrokerSymbol(InstrumentType.OPTION, symbol);
         }
         return ticker;
     }

--- a/implementations/market-data-api/paradex-market-data-impl/src/test/java/com/fueledbychai/marketdata/paradex/ParadexQuoteEngineTest.java
+++ b/implementations/market-data-api/paradex-market-data-impl/src/test/java/com/fueledbychai/marketdata/paradex/ParadexQuoteEngineTest.java
@@ -3,7 +3,11 @@ package com.fueledbychai.marketdata.paradex;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.util.concurrent.CountDownLatch;
@@ -49,6 +53,199 @@ class ParadexQuoteEngineTest {
         assertNotNull(quote);
         assertEquals(1.0, quote.getValue(QuoteType.FUNDING_RATE_HOURLY_BPS).doubleValue(), 1.0e-9);
         assertEquals(87.6, quote.getValue(QuoteType.FUNDING_RATE_APR).doubleValue(), 1.0e-9);
+    }
+
+    @Test
+    void newSummaryUpdateOptionWithEmptyFieldsDoesNotThrow() throws Exception {
+        // Newly-listed/idle option markets emit empty strings for last/mark/oi/volume
+        // until there's activity. We must publish a quote without throwing.
+        Ticker optionTicker = newTicker("BTC-USD-26JUN26-67000-C", InstrumentType.OPTION, "0.01", 0);
+        ParadexQuoteEngine engine = new ParadexQuoteEngine(mock(IParadexRestApi.class),
+                optionRegistryByBrokerSymbol(optionTicker));
+
+        ILevel1Quote quote = captureNextLevel1Quote(engine, () -> engine.newSummaryUpdate(1771375190278L,
+                "BTC-USD-26JUN26-67000-C", "", "", "", "", "", "", "", ""));
+
+        assertNotNull(quote);
+        assertEquals("BTC-USD-26JUN26-67000-C", quote.getTicker().getSymbol());
+        assertFalse(quote.containsType(QuoteType.LAST));
+        assertFalse(quote.containsType(QuoteType.MARK_PRICE));
+        assertFalse(quote.containsType(QuoteType.OPEN_INTEREST));
+        assertFalse(quote.containsType(QuoteType.VOLUME));
+        assertFalse(quote.containsType(QuoteType.UNDERLYING_PRICE));
+        assertFalse(quote.containsType(QuoteType.VOLUME_NOTIONAL));
+        assertFalse(quote.containsType(QuoteType.OPEN_INTEREST_NOTIONAL));
+    }
+
+    @Test
+    void newSummaryUpdateOptionWithPartialFieldsPopulatesOnlyAvailableQuotes() throws Exception {
+        Ticker optionTicker = newTicker("BTC-USD-26JUN26-67000-C", InstrumentType.OPTION, "0.01", 0);
+        ParadexQuoteEngine engine = new ParadexQuoteEngine(mock(IParadexRestApi.class),
+                optionRegistryByBrokerSymbol(optionTicker));
+
+        // Only last/mark/volume populated; openInterest and underlyingPrice empty.
+        ILevel1Quote quote = captureNextLevel1Quote(engine, () -> engine.newSummaryUpdate(1771375190278L,
+                "BTC-USD-26JUN26-67000-C", "", "", "1500.5", "1505.0", "", "10", "", ""));
+
+        assertNotNull(quote);
+        assertEquals(new BigDecimal("1500.50"), quote.getValue(QuoteType.LAST));
+        assertEquals(new BigDecimal("1505.00"), quote.getValue(QuoteType.MARK_PRICE));
+        assertEquals(new BigDecimal("10"), quote.getValue(QuoteType.VOLUME));
+        // Notional volume = lastPrice * volume24h, both available
+        assertEquals(new BigDecimal("15005.00"), quote.getValue(QuoteType.VOLUME_NOTIONAL));
+        // Open interest fields not present
+        assertFalse(quote.containsType(QuoteType.OPEN_INTEREST));
+        assertFalse(quote.containsType(QuoteType.OPEN_INTEREST_NOTIONAL));
+        assertFalse(quote.containsType(QuoteType.UNDERLYING_PRICE));
+    }
+
+    private static ITickerRegistry optionRegistryByBrokerSymbol(Ticker optionTicker) {
+        return new ITickerRegistry() {
+            @Override
+            public Ticker lookupByBrokerSymbol(InstrumentType instrumentType, String tickerString) {
+                if (instrumentType == InstrumentType.OPTION && optionTicker.getSymbol().equals(tickerString)) {
+                    return optionTicker;
+                }
+                return null;
+            }
+
+            @Override
+            public Ticker lookupByCommonSymbol(InstrumentType instrumentType, String commonSymbol) {
+                return null;
+            }
+
+            @Override
+            public String commonSymbolToExchangeSymbol(InstrumentType instrumentType, String commonSymbol) {
+                return null;
+            }
+        };
+    }
+
+    @Test
+    void requestLevel1SnapshotResolvesCommonSymbolToExchangeSymbol() {
+        // Common-symbol form (with slash). The engine must resolve it via the
+        // ticker registry to the proper Paradex exchange symbol before calling
+        // getBBO; otherwise the slash splits the URL and Paradex returns 401.
+        Ticker commonSymbolTicker = new Ticker("BTC/USD-20260626-67000-C")
+                .setExchange(Exchange.PARADEX)
+                .setInstrumentType(InstrumentType.OPTION)
+                .setMinimumTickSize(new BigDecimal("0.01"));
+        Ticker resolvedTicker = newTicker("BTC-USD-26JUN26-67000-C", InstrumentType.OPTION, "0.01", 0);
+
+        IParadexRestApi restApi = mock(IParadexRestApi.class);
+        when(restApi.getBBO("BTC-USD-26JUN26-67000-C"))
+                .thenReturn(com.google.gson.JsonParser
+                        .parseString("{\"market\":\"BTC-USD-26JUN26-67000-C\",\"bid\":\"100\",\"bid_size\":\"1\","
+                                + "\"ask\":\"110\",\"ask_size\":\"2\"}")
+                        .getAsJsonObject());
+
+        ITickerRegistry registry = optionRegistry(commonSymbolTicker.getSymbol(), resolvedTicker);
+        ParadexQuoteEngine engine = new ParadexQuoteEngine(restApi, registry);
+
+        ILevel1Quote quote = engine.requestLevel1Snapshot(commonSymbolTicker);
+
+        verify(restApi).getBBO(eq("BTC-USD-26JUN26-67000-C"));
+        assertNotNull(quote);
+    }
+
+    @Test
+    void requestLevel1SnapshotPassesExchangeSymbolThrough() {
+        // Exchange-symbol form (no slash). The engine should pass it directly.
+        Ticker perpTicker = newTicker("BTC-USD-PERP", InstrumentType.PERPETUAL_FUTURES, "0.1", 8);
+
+        IParadexRestApi restApi = mock(IParadexRestApi.class);
+        when(restApi.getBBO("BTC-USD-PERP"))
+                .thenReturn(com.google.gson.JsonParser
+                        .parseString("{\"market\":\"BTC-USD-PERP\",\"bid\":\"100\",\"bid_size\":\"1\","
+                                + "\"ask\":\"110\",\"ask_size\":\"2\"}")
+                        .getAsJsonObject());
+
+        ParadexQuoteEngine engine = new ParadexQuoteEngine(restApi, registryWith(perpTicker, null));
+
+        ILevel1Quote quote = engine.requestLevel1Snapshot(perpTicker);
+
+        verify(restApi).getBBO(eq("BTC-USD-PERP"));
+        assertNotNull(quote);
+    }
+
+    @Test
+    void requestLevel1SnapshotResolvesSlashSeparatedOptionSymbol() {
+        // Slash-separated mirror of the Paradex exchange symbol — the form
+        // some upstream services pass because '/' is more URL-friendly.
+        Ticker badTicker = new Ticker("BTC/USD/24APR26/75000/C")
+                .setExchange(Exchange.PARADEX)
+                .setInstrumentType(InstrumentType.OPTION)
+                .setMinimumTickSize(new BigDecimal("0.01"));
+        Ticker canonicalTicker = newTicker("BTC-USD-24APR26-75000-C", InstrumentType.OPTION, "0.01", 0);
+
+        IParadexRestApi restApi = mock(IParadexRestApi.class);
+        when(restApi.getBBO("BTC-USD-24APR26-75000-C"))
+                .thenReturn(com.google.gson.JsonParser
+                        .parseString("{\"market\":\"BTC-USD-24APR26-75000-C\",\"bid\":\"100\",\"bid_size\":\"1\","
+                                + "\"ask\":\"110\",\"ask_size\":\"2\"}")
+                        .getAsJsonObject());
+
+        // Registry that returns the canonical ticker via lookupByCommonSymbol
+        // for the slash-separated input.
+        ITickerRegistry registry = optionRegistry("BTC/USD/24APR26/75000/C", canonicalTicker);
+        ParadexQuoteEngine engine = new ParadexQuoteEngine(restApi, registry);
+
+        ILevel1Quote quote = engine.requestLevel1Snapshot(badTicker);
+
+        verify(restApi).getBBO(eq("BTC-USD-24APR26-75000-C"));
+        assertNotNull(quote);
+        // The published quote should carry the canonical Ticker, so downstream
+        // listeners see the proper Paradex exchange symbol, not the user's input.
+        assertEquals("BTC-USD-24APR26-75000-C", quote.getTicker().getSymbol());
+    }
+
+    @Test
+    void canonicalizePrefersBrokerSymbolLookupBeforeCommonSymbolLookup() {
+        // A ticker whose symbol already matches a registered broker symbol
+        // should be canonicalized via the fast (lookupByBrokerSymbol) path,
+        // even if the input ticker instance is a different object than the
+        // registered one. This guarantees downstream maps key on the
+        // registry-cached canonical Ticker.
+        Ticker registered = newTicker("BTC-USD-PERP", InstrumentType.PERPETUAL_FUTURES, "0.1", 8);
+        Ticker userInput = newTicker("BTC-USD-PERP", InstrumentType.PERPETUAL_FUTURES, "0.1", 8);
+
+        IParadexRestApi restApi = mock(IParadexRestApi.class);
+        when(restApi.getBBO("BTC-USD-PERP"))
+                .thenReturn(com.google.gson.JsonParser
+                        .parseString("{\"market\":\"BTC-USD-PERP\",\"bid\":\"100\",\"bid_size\":\"1\","
+                                + "\"ask\":\"110\",\"ask_size\":\"2\"}")
+                        .getAsJsonObject());
+
+        ParadexQuoteEngine engine = new ParadexQuoteEngine(restApi, registryWith(registered, null));
+        ILevel1Quote quote = engine.requestLevel1Snapshot(userInput);
+
+        verify(restApi).getBBO(eq("BTC-USD-PERP"));
+        assertNotNull(quote);
+        // The published quote's ticker should be the registry-cached instance,
+        // not the user's input — same symbol, same instance.
+        assertSame(registered, quote.getTicker());
+    }
+
+    private static ITickerRegistry optionRegistry(String commonSymbol, Ticker resolved) {
+        return new ITickerRegistry() {
+            @Override
+            public Ticker lookupByBrokerSymbol(InstrumentType instrumentType, String tickerString) {
+                return null;
+            }
+
+            @Override
+            public Ticker lookupByCommonSymbol(InstrumentType instrumentType, String requestedCommonSymbol) {
+                if (instrumentType == InstrumentType.OPTION && commonSymbol.equals(requestedCommonSymbol)) {
+                    return resolved;
+                }
+                return null;
+            }
+
+            @Override
+            public String commonSymbolToExchangeSymbol(InstrumentType instrumentType, String requestedCommonSymbol) {
+                return null;
+            }
+        };
     }
 
     private static ILevel1Quote captureNextLevel1Quote(ParadexQuoteEngine engine, Runnable action) throws Exception {


### PR DESCRIPTION
- Added support for structured common symbols for OPTION instruments in ParadexRestApi.
- Implemented buildOptionCommonSymbol method to encode strike, expiry, and right into common symbols.
- Updated parseInstrumentDescriptors to handle OPTION instruments and populate common symbols correctly.
- Introduced ParadexTickerTranslator to translate InstrumentDescriptors into Tickers, populating option-specific fields.
- Added tests for new functionality in ParadexTickerRegistryTest and ParadexQuoteEngineTest.
- Improved BBO URL building to handle slashes in market symbols correctly.
- Enhanced error handling for missing option metadata in parseInstrumentDescriptors.

## Description

Brief description of changes made

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Broker Impact

- [ ] Interactive Brokers
- [ ] Paradex
- [ ] Hyperliquid
- [ ] Paper Broker
- [ ] Core API
- [ ] No broker impact

## Testing

- [ ] Unit tests pass (`mvn test`)
- [ ] Integration tests pass (`mvn verify`)
- [ ] Manual testing completed
- [ ] New tests added for new functionality

## Documentation

- [ ] Code comments updated
- [ ] README updated (if applicable)
- [ ] CHANGELOG.md updated
- [ ] API documentation updated (if applicable)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
