### PR TITLE
feat: Add HibachiMarketDataExample under CryptoExamples

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,37 @@
       "WebFetch(domain:docs.lighter.xyz)",
       "WebFetch(domain:docs.aster.finance)",
       "WebFetch(domain:hyperliquid.gitbook.io)",
-      "WebFetch(domain:drift-labs.github.io)"
+      "WebFetch(domain:drift-labs.github.io)",
+      "WebFetch(domain:api-doc.hibachi.xyz)",
+      "Bash(curl -sS -A \"Mozilla/5.0\" -o /tmp/hibachi_docs.html -w \"%{http_code}\\\\n\" https://api-doc.hibachi.xyz/)",
+      "Bash(curl -sS -A \"Mozilla/5.0\" -o /tmp/hibachi_collection.json -w \"%{http_code}\\\\n\" \"https://api-doc.hibachi.xyz/api/collections/38930884/2sAXxQfD4P?environment=38930884-e5245e24-69ae-4eb4-bb10-aaa4447be197&segregateAuth=true&versionTag=latest\")",
+      "Bash(curl -sS -A \"Mozilla/5.0\" -o /tmp/hibachi_ws_page.html -w \"%{http_code}\\\\n\" \"https://www.postman.com/hibachi-xyz/hibachi-public/collection/6707f03b7c82ad6d2f10477c\")",
+      "Bash(curl -sS -A \"Mozilla/5.0\" \"https://www.postman.com/_api/workspace/public/info?handle=hibachi-xyz&slug=hibachi-public\")",
+      "Bash(curl -sS -A \"Mozilla/5.0\" \"https://www.postman.com/_api/collection/6707f03b7c82ad6d2f10477c\")",
+      "Bash(curl -sS -A \"Mozilla/5.0\" \"https://www.postman.com/_api/collection/6707f03b7c82ad6d2f10477c?owner=38930884\" -o /tmp/hibachi_ws.json -w \"%{http_code}\\\\n\")",
+      "Bash(curl -sS -A \"Mozilla/5.0\" \"https://www.postman.com/_api/collection/6707f03b7c82ad6d2f10477c/summary?user_id=38930884\" -o /tmp/ws_summary.json -w \"%{http_code}\\\\n\")",
+      "WebFetch(domain:github.com)",
+      "Bash(gh api:*)",
+      "Bash(python3 -c \"import sys,json; d=json.load\\(sys.stdin\\); [print\\(x['type'],x['path']\\) for x in d]\")",
+      "Bash(python3 -c \"import sys,json; d=json.load\\(sys.stdin\\); [print\\(x['path']\\) for x in d.get\\('tree',[]\\) if x['type']=='blob']\")",
+      "Bash(curl -sS \"https://api.github.com/repos/hibachi-xyz/hibachi_sdk/git/trees/main?recursive=1\" -o /tmp/sdk_tree.json -w \"%{http_code}\\\\n\")",
+      "Bash(python3 -c \"import json; d=json.load\\(open\\('/tmp/sdk_tree.json'\\)\\); [print\\(x['path']\\) for x in d.get\\('tree',[]\\) if x['type']=='blob']\")",
+      "Bash(curl -sS https://raw.githubusercontent.com/hibachi-xyz/hibachi_sdk/main/python/hibachi_xyz/__TRACKED_VAR__ -o /tmp/hibachi_sdk/__TRACKED_VAR__ -w '__TRACKED_VAR__: %{http_code}\\\\n')",
+      "Bash(curl -sS https://raw.githubusercontent.com/hibachi-xyz/hibachi_sdk/main/python/examples/__TRACKED_VAR__ -o /tmp/hibachi_sdk/__TRACKED_VAR__ -w '__TRACKED_VAR__: %{http_code}\\\\n')",
+      "Bash(python3 -c ':*)",
+      "Bash(ls -lat /Users/robterpilowski/.claude/projects/-Users-robterpilowski-Code-JavaProjects-FueledByChaiTrading/*.jsonl)",
+      "Bash(grep -v \"^$\")",
+      "Bash(mvn -pl commons/hibachi-common-api -am test -q)",
+      "Bash(git add *)",
+      "Bash(git commit -m ' *)",
+      "Bash(mvn install *)",
+      "Bash(mvn -pl commons/hibachi-common-api,implementations/market-data-api/hibachi-market-data-impl,implementations/broker-api/hibachi-broker-api-impl test -am)",
+      "Bash(mvn -q -pl commons/hibachi-common-api -am compile -DskipTests)",
+      "Bash(mvn -pl implementations/market-data-api/hibachi-market-data-impl -am compile -DskipTests -q)",
+      "Bash(mvn -pl examples/CryptoExamples -am compile -DskipTests -q)"
+    ],
+    "additionalDirectories": [
+      "/Users/robicemilowski/Code/JavaProjects/FueledByChaiTrading/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/market"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ commons/lighter-common-api/local-resources/lighter.properties
 # Credentials files - never check these in
 **/aster-credentials.properties
 examples/CryptoExamples/aster-credentials.properties.properties
+.claude/settings.json

--- a/commons/fueledbychai-commons-api/src/main/java/com/fueledbychai/data/Exchange.java
+++ b/commons/fueledbychai-commons-api/src/main/java/com/fueledbychai/data/Exchange.java
@@ -61,9 +61,10 @@ public class Exchange implements Serializable {
     public static final Exchange BYBIT = new Exchange("BYBIT");
     public static final Exchange DRIFT = new Exchange("DRIFT");
     public static final Exchange ASTER = new Exchange("ASTER");
+    public static final Exchange HIBACHI = new Exchange("HIBACHI");
     public static final Exchange[] ALL_EXCHANGES = { ARCA, GLOBEX, NYMEX, CBOE, ECBOT, NYBOT, CFE, NYSE_LIFFE, IDEALPRO,
             PSE, INTERACTIVE_BROKERS_SMART, NASDAQ, TSEJ, SEHKNTL, SEHK, HKFE, OSE, SGX, BOX, DYDX, HYPERLIQUID,
-            PARADEX, LIGHTER, BINANCE_SPOT, BINANCE_FUTURES, DERIBIT, OKX, BYBIT, DRIFT, ASTER };
+            PARADEX, LIGHTER, BINANCE_SPOT, BINANCE_FUTURES, DERIBIT, OKX, BYBIT, DRIFT, ASTER, HIBACHI };
 
 
     protected String exchangeName;

--- a/commons/hibachi-common-api/pom.xml
+++ b/commons/hibachi-common-api/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.fueledbychai</groupId>
+        <artifactId>fueledbychai-commons</artifactId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>hibachi-common-api</artifactId>
+    <version>0.2.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>fueledbychai-commons-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.java-websocket</groupId>
+            <artifactId>Java-WebSocket</artifactId>
+            <version>1.5.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20240303</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M9</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/HibachiExchangeCapabilitiesProvider.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/HibachiExchangeCapabilitiesProvider.java
@@ -1,0 +1,25 @@
+package com.fueledbychai.hibachi.common;
+
+import com.fueledbychai.data.Exchange;
+import com.fueledbychai.data.InstrumentType;
+import com.fueledbychai.util.DefaultExchangeCapabilities;
+import com.fueledbychai.util.ExchangeCapabilities;
+import com.fueledbychai.util.ExchangeCapabilitiesProvider;
+
+public class HibachiExchangeCapabilitiesProvider implements ExchangeCapabilitiesProvider {
+
+    @Override
+    public Exchange getExchange() {
+        return Exchange.HIBACHI;
+    }
+
+    @Override
+    public ExchangeCapabilities getCapabilities() {
+        return DefaultExchangeCapabilities.builder(Exchange.HIBACHI)
+                .supportsStreaming(true)
+                .supportsBrokerage(true)
+                .supportsHistoricalData(true)
+                .addInstrumentType(InstrumentType.PERPETUAL_FUTURES)
+                .build();
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/HibachiTickerRegistry.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/HibachiTickerRegistry.java
@@ -1,0 +1,73 @@
+package com.fueledbychai.hibachi.common;
+
+import com.fueledbychai.data.Exchange;
+import com.fueledbychai.data.InstrumentType;
+import com.fueledbychai.data.TickerTranslator;
+import com.fueledbychai.hibachi.common.api.IHibachiRestApi;
+import com.fueledbychai.util.AbstractTickerRegistry;
+import com.fueledbychai.util.ExchangeRestApiFactory;
+import com.fueledbychai.util.ITickerRegistry;
+
+/**
+ * Hibachi ticker registry. Symbols are already canonical ({@code BTC/USDT-P}), so the
+ * common/exchange symbol mapping is a passthrough.
+ */
+public class HibachiTickerRegistry extends AbstractTickerRegistry implements ITickerRegistry {
+
+    protected static ITickerRegistry instance;
+    protected final IHibachiRestApi restApi;
+
+    public static ITickerRegistry getInstance(IHibachiRestApi restApi) {
+        if (instance == null) {
+            instance = new HibachiTickerRegistry(restApi);
+        }
+        return instance;
+    }
+
+    public static ITickerRegistry getInstance() {
+        if (instance == null) {
+            instance = new HibachiTickerRegistry(
+                    ExchangeRestApiFactory.getPublicApi(Exchange.HIBACHI, IHibachiRestApi.class));
+        }
+        return instance;
+    }
+
+    protected HibachiTickerRegistry(IHibachiRestApi restApi) {
+        super(new TickerTranslator());
+        if (restApi == null) {
+            throw new IllegalArgumentException("restApi is required");
+        }
+        this.restApi = restApi;
+        initialize();
+    }
+
+    protected void initialize() {
+        registerDescriptors(restApi.getAllInstrumentsForType(InstrumentType.PERPETUAL_FUTURES));
+    }
+
+    @Override
+    protected boolean supportsInstrumentType(InstrumentType instrumentType) {
+        return instrumentType == InstrumentType.PERPETUAL_FUTURES;
+    }
+
+    @Override
+    public String commonSymbolToExchangeSymbol(InstrumentType instrumentType, String commonSymbol) {
+        requireSupportedInstrumentType(instrumentType);
+        if (commonSymbol == null) {
+            return null;
+        }
+        String normalized = commonSymbol.trim().toUpperCase();
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        // Hibachi uses the canonical form directly, e.g. BTC/USDT-P.
+        if (normalized.endsWith("-P")) {
+            return normalized;
+        }
+        if (normalized.contains("/")) {
+            return normalized + "-P";
+        }
+        // Bare base (e.g. "BTC") — assume USDT perp.
+        return normalized + "/USDT-P";
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/HibachiTickerRegistry.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/HibachiTickerRegistry.java
@@ -64,6 +64,9 @@ public class HibachiTickerRegistry extends AbstractTickerRegistry implements ITi
         if (normalized.endsWith("-P")) {
             return normalized;
         }
+        if (normalized.endsWith("/P")) {
+            return normalized.substring(0, normalized.length() - 2) + "-P";
+        }
         if (normalized.contains("/")) {
             return normalized + "-P";
         }

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/HibachiTickerRegistryProvider.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/HibachiTickerRegistryProvider.java
@@ -1,0 +1,18 @@
+package com.fueledbychai.hibachi.common;
+
+import com.fueledbychai.data.Exchange;
+import com.fueledbychai.util.ITickerRegistry;
+import com.fueledbychai.util.TickerRegistryProvider;
+
+public class HibachiTickerRegistryProvider implements TickerRegistryProvider {
+
+    @Override
+    public Exchange getExchange() {
+        return Exchange.HIBACHI;
+    }
+
+    @Override
+    public ITickerRegistry getRegistry() {
+        return HibachiTickerRegistry.getInstance();
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/HibachiConfiguration.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/HibachiConfiguration.java
@@ -1,0 +1,145 @@
+package com.fueledbychai.hibachi.common.api;
+
+public class HibachiConfiguration {
+
+    public static final String HIBACHI_ENVIRONMENT = "hibachi.environment";
+    public static final String HIBACHI_PROD_REST_URL = "hibachi.prod.rest.url";
+    public static final String HIBACHI_PROD_DATA_REST_URL = "hibachi.prod.data.rest.url";
+    public static final String HIBACHI_PROD_WS_MARKET_URL = "hibachi.prod.ws.market.url";
+    public static final String HIBACHI_PROD_WS_ACCOUNT_URL = "hibachi.prod.ws.account.url";
+    public static final String HIBACHI_PROD_WS_TRADE_URL = "hibachi.prod.ws.trade.url";
+    public static final String HIBACHI_TESTNET_REST_URL = "hibachi.testnet.rest.url";
+    public static final String HIBACHI_TESTNET_DATA_REST_URL = "hibachi.testnet.data.rest.url";
+    public static final String HIBACHI_TESTNET_WS_MARKET_URL = "hibachi.testnet.ws.market.url";
+    public static final String HIBACHI_TESTNET_WS_ACCOUNT_URL = "hibachi.testnet.ws.account.url";
+    public static final String HIBACHI_TESTNET_WS_TRADE_URL = "hibachi.testnet.ws.trade.url";
+    public static final String HIBACHI_API_KEY = "hibachi.api.key";
+    public static final String HIBACHI_API_SECRET = "hibachi.api.secret";
+    public static final String HIBACHI_ACCOUNT_ID = "hibachi.account.id";
+    public static final String HIBACHI_PUBLIC_KEY = "hibachi.public.key";
+    public static final String HIBACHI_PRIVATE_KEY = "hibachi.private.key";
+    public static final String HIBACHI_CLIENT = "hibachi.client";
+    public static final String HIBACHI_ACCOUNT_WS_PING_SECONDS = "hibachi.account.ws.ping.seconds";
+
+    private static final String DEFAULT_ENVIRONMENT = "prod";
+    private static final String DEFAULT_PROD_REST_URL = "https://api.hibachi.xyz";
+    private static final String DEFAULT_PROD_DATA_REST_URL = "https://data-api.hibachi.xyz";
+    private static final String DEFAULT_PROD_WS_MARKET_URL = "wss://data-api.hibachi.xyz/ws/market";
+    private static final String DEFAULT_PROD_WS_ACCOUNT_URL = "wss://api.hibachi.xyz/ws/account";
+    private static final String DEFAULT_PROD_WS_TRADE_URL = "wss://api.hibachi.xyz/ws/trade";
+    private static final String DEFAULT_TESTNET_REST_URL = "https://api-test.hibachi.xyz";
+    private static final String DEFAULT_TESTNET_DATA_REST_URL = "https://data-api-test.hibachi.xyz";
+    private static final String DEFAULT_TESTNET_WS_MARKET_URL = "wss://data-api-test.hibachi.xyz/ws/market";
+    private static final String DEFAULT_TESTNET_WS_ACCOUNT_URL = "wss://api-test.hibachi.xyz/ws/account";
+    private static final String DEFAULT_TESTNET_WS_TRADE_URL = "wss://api-test.hibachi.xyz/ws/trade";
+    private static final String DEFAULT_CLIENT = "FueledByChaiJavaSDK";
+    private static final long DEFAULT_ACCOUNT_WS_PING_SECONDS = 14L;
+
+    private static volatile HibachiConfiguration instance;
+    private static final Object LOCK = new Object();
+
+    private final String environment;
+    private final String restUrl;
+    private final String dataRestUrl;
+    private final String marketWsUrl;
+    private final String accountWsUrl;
+    private final String tradeWsUrl;
+    private final String apiKey;
+    private final String apiSecret;
+    private final String accountId;
+    private final String publicKey;
+    private final String privateKey;
+    private final String client;
+    private final long accountWsPingSeconds;
+
+    public static HibachiConfiguration getInstance() {
+        if (instance == null) {
+            synchronized (LOCK) {
+                if (instance == null) {
+                    instance = new HibachiConfiguration();
+                }
+            }
+        }
+        return instance;
+    }
+
+    public static void reset() {
+        synchronized (LOCK) {
+            instance = null;
+        }
+    }
+
+    private HibachiConfiguration() {
+        this.environment = read(HIBACHI_ENVIRONMENT, DEFAULT_ENVIRONMENT);
+        boolean production = isProductionEnvironment(this.environment);
+        this.restUrl = production ? read(HIBACHI_PROD_REST_URL, DEFAULT_PROD_REST_URL)
+                : read(HIBACHI_TESTNET_REST_URL, DEFAULT_TESTNET_REST_URL);
+        this.dataRestUrl = production ? read(HIBACHI_PROD_DATA_REST_URL, DEFAULT_PROD_DATA_REST_URL)
+                : read(HIBACHI_TESTNET_DATA_REST_URL, DEFAULT_TESTNET_DATA_REST_URL);
+        this.marketWsUrl = production ? read(HIBACHI_PROD_WS_MARKET_URL, DEFAULT_PROD_WS_MARKET_URL)
+                : read(HIBACHI_TESTNET_WS_MARKET_URL, DEFAULT_TESTNET_WS_MARKET_URL);
+        this.accountWsUrl = production ? read(HIBACHI_PROD_WS_ACCOUNT_URL, DEFAULT_PROD_WS_ACCOUNT_URL)
+                : read(HIBACHI_TESTNET_WS_ACCOUNT_URL, DEFAULT_TESTNET_WS_ACCOUNT_URL);
+        this.tradeWsUrl = production ? read(HIBACHI_PROD_WS_TRADE_URL, DEFAULT_PROD_WS_TRADE_URL)
+                : read(HIBACHI_TESTNET_WS_TRADE_URL, DEFAULT_TESTNET_WS_TRADE_URL);
+        this.apiKey = read(HIBACHI_API_KEY, null);
+        this.apiSecret = read(HIBACHI_API_SECRET, null);
+        this.accountId = read(HIBACHI_ACCOUNT_ID, null);
+        this.publicKey = read(HIBACHI_PUBLIC_KEY, null);
+        this.privateKey = read(HIBACHI_PRIVATE_KEY, null);
+        this.client = read(HIBACHI_CLIENT, DEFAULT_CLIENT);
+        this.accountWsPingSeconds = readLong(HIBACHI_ACCOUNT_WS_PING_SECONDS, DEFAULT_ACCOUNT_WS_PING_SECONDS);
+    }
+
+    private static String read(String key, String defaultValue) {
+        String value = System.getProperty(key);
+        if (value == null || value.isBlank()) {
+            value = System.getenv(key.toUpperCase().replace('.', '_'));
+        }
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        return value;
+    }
+
+    private static long readLong(String key, long defaultValue) {
+        String value = read(key, null);
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException ignored) {
+            return defaultValue;
+        }
+    }
+
+    public String getEnvironment() { return environment; }
+    public String getRestUrl() { return restUrl; }
+    public String getDataRestUrl() { return dataRestUrl; }
+    public String getMarketWsUrl() { return marketWsUrl; }
+    public String getAccountWsUrl() { return accountWsUrl; }
+    public String getTradeWsUrl() { return tradeWsUrl; }
+    public String getApiKey() { return apiKey; }
+    public String getApiSecret() { return apiSecret; }
+    public String getAccountId() { return accountId; }
+    public String getPublicKey() { return publicKey; }
+    public String getPrivateKey() { return privateKey; }
+    public String getClient() { return client; }
+    public long getAccountWsPingSeconds() { return accountWsPingSeconds; }
+
+    public boolean hasPrivateApiConfiguration() {
+        return apiKey != null && !apiKey.isBlank()
+                && apiSecret != null && !apiSecret.isBlank()
+                && accountId != null && !accountId.isBlank();
+    }
+
+    public boolean isProductionEnvironment() {
+        return isProductionEnvironment(environment);
+    }
+
+    private static boolean isProductionEnvironment(String environment) {
+        return environment == null || environment.isBlank() || "prod".equalsIgnoreCase(environment)
+                || "production".equalsIgnoreCase(environment) || "mainnet".equalsIgnoreCase(environment);
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/HibachiConfiguration.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/HibachiConfiguration.java
@@ -1,5 +1,7 @@
 package com.fueledbychai.hibachi.common.api;
 
+import java.math.BigDecimal;
+
 public class HibachiConfiguration {
 
     public static final String HIBACHI_ENVIRONMENT = "hibachi.environment";
@@ -20,6 +22,7 @@ public class HibachiConfiguration {
     public static final String HIBACHI_PRIVATE_KEY = "hibachi.private.key";
     public static final String HIBACHI_CLIENT = "hibachi.client";
     public static final String HIBACHI_ACCOUNT_WS_PING_SECONDS = "hibachi.account.ws.ping.seconds";
+    public static final String HIBACHI_ORDER_MAX_FEES_PERCENT = "hibachi.order.max.fees.percent";
 
     private static final String DEFAULT_ENVIRONMENT = "prod";
     private static final String DEFAULT_PROD_REST_URL = "https://api.hibachi.xyz";
@@ -34,6 +37,9 @@ public class HibachiConfiguration {
     private static final String DEFAULT_TESTNET_WS_TRADE_URL = "wss://api-test.hibachi.xyz/ws/trade";
     private static final String DEFAULT_CLIENT = "FueledByChaiJavaSDK";
     private static final long DEFAULT_ACCOUNT_WS_PING_SECONDS = 14L;
+    // Hibachi fee schedule (as of the integration work): maker = 0 bps, taker = 5 bps.
+    // maxFeesPercent is a cap, so default to the taker rate (0.05% = 5 bps) to cover both sides.
+    private static final BigDecimal DEFAULT_ORDER_MAX_FEES_PERCENT = new BigDecimal("0.05");
 
     private static volatile HibachiConfiguration instance;
     private static final Object LOCK = new Object();
@@ -51,6 +57,7 @@ public class HibachiConfiguration {
     private final String privateKey;
     private final String client;
     private final long accountWsPingSeconds;
+    private final BigDecimal orderMaxFeesPercent;
 
     public static HibachiConfiguration getInstance() {
         if (instance == null) {
@@ -89,6 +96,7 @@ public class HibachiConfiguration {
         this.privateKey = read(HIBACHI_PRIVATE_KEY, null);
         this.client = read(HIBACHI_CLIENT, DEFAULT_CLIENT);
         this.accountWsPingSeconds = readLong(HIBACHI_ACCOUNT_WS_PING_SECONDS, DEFAULT_ACCOUNT_WS_PING_SECONDS);
+        this.orderMaxFeesPercent = readBigDecimal(HIBACHI_ORDER_MAX_FEES_PERCENT, DEFAULT_ORDER_MAX_FEES_PERCENT);
     }
 
     private static String read(String key, String defaultValue) {
@@ -114,6 +122,18 @@ public class HibachiConfiguration {
         }
     }
 
+    private static BigDecimal readBigDecimal(String key, BigDecimal defaultValue) {
+        String value = read(key, null);
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        try {
+            return new BigDecimal(value);
+        } catch (NumberFormatException ignored) {
+            return defaultValue;
+        }
+    }
+
     public String getEnvironment() { return environment; }
     public String getRestUrl() { return restUrl; }
     public String getDataRestUrl() { return dataRestUrl; }
@@ -127,6 +147,7 @@ public class HibachiConfiguration {
     public String getPrivateKey() { return privateKey; }
     public String getClient() { return client; }
     public long getAccountWsPingSeconds() { return accountWsPingSeconds; }
+    public BigDecimal getOrderMaxFeesPercent() { return orderMaxFeesPercent; }
 
     public boolean hasPrivateApiConfiguration() {
         return apiKey != null && !apiKey.isBlank()

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/HibachiContract.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/HibachiContract.java
@@ -1,0 +1,123 @@
+package com.fueledbychai.hibachi.common.api;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents one Hibachi perpetual future contract as returned by
+ * {@code GET /market/exchange-info} on the data-api host.
+ *
+ * <p>The {@code id}, {@code underlyingDecimals}, and {@code settlementDecimals} fields are
+ * required inputs for signing order payloads. See {@link HibachiPayloadPacker} and the
+ * Python SDK at {@code hibachi_xyz/api.py} ({@code _create_order_request_data}).
+ */
+public class HibachiContract {
+
+    private final int id;
+    private final String symbol;
+    private final String displayName;
+    private final String underlyingSymbol;
+    private final String settlementSymbol;
+    private final int underlyingDecimals;
+    private final int settlementDecimals;
+    private final BigDecimal tickSize;
+    private final BigDecimal stepSize;
+    private final BigDecimal minOrderSize;
+    private final BigDecimal minNotional;
+    private final BigDecimal initialMarginRate;
+    private final BigDecimal maintenanceMarginRate;
+    private final String status;
+    private final List<String> orderbookGranularities;
+    private final Long marketOpenTimestamp;
+    private final Long marketCloseTimestamp;
+    private final Long marketCreationTimestamp;
+
+    private HibachiContract(Builder b) {
+        this.id = b.id;
+        this.symbol = b.symbol;
+        this.displayName = b.displayName;
+        this.underlyingSymbol = b.underlyingSymbol;
+        this.settlementSymbol = b.settlementSymbol;
+        this.underlyingDecimals = b.underlyingDecimals;
+        this.settlementDecimals = b.settlementDecimals;
+        this.tickSize = b.tickSize;
+        this.stepSize = b.stepSize;
+        this.minOrderSize = b.minOrderSize;
+        this.minNotional = b.minNotional;
+        this.initialMarginRate = b.initialMarginRate;
+        this.maintenanceMarginRate = b.maintenanceMarginRate;
+        this.status = b.status;
+        this.orderbookGranularities = b.orderbookGranularities == null
+                ? Collections.emptyList()
+                : List.copyOf(b.orderbookGranularities);
+        this.marketOpenTimestamp = b.marketOpenTimestamp;
+        this.marketCloseTimestamp = b.marketCloseTimestamp;
+        this.marketCreationTimestamp = b.marketCreationTimestamp;
+    }
+
+    public int getId() { return id; }
+    public String getSymbol() { return symbol; }
+    public String getDisplayName() { return displayName; }
+    public String getUnderlyingSymbol() { return underlyingSymbol; }
+    public String getSettlementSymbol() { return settlementSymbol; }
+    public int getUnderlyingDecimals() { return underlyingDecimals; }
+    public int getSettlementDecimals() { return settlementDecimals; }
+    public BigDecimal getTickSize() { return tickSize; }
+    public BigDecimal getStepSize() { return stepSize; }
+    public BigDecimal getMinOrderSize() { return minOrderSize; }
+    public BigDecimal getMinNotional() { return minNotional; }
+    public BigDecimal getInitialMarginRate() { return initialMarginRate; }
+    public BigDecimal getMaintenanceMarginRate() { return maintenanceMarginRate; }
+    public String getStatus() { return status; }
+    public List<String> getOrderbookGranularities() { return orderbookGranularities; }
+    public Long getMarketOpenTimestamp() { return marketOpenTimestamp; }
+    public Long getMarketCloseTimestamp() { return marketCloseTimestamp; }
+    public Long getMarketCreationTimestamp() { return marketCreationTimestamp; }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private int id;
+        private String symbol;
+        private String displayName;
+        private String underlyingSymbol;
+        private String settlementSymbol;
+        private int underlyingDecimals;
+        private int settlementDecimals;
+        private BigDecimal tickSize;
+        private BigDecimal stepSize;
+        private BigDecimal minOrderSize;
+        private BigDecimal minNotional;
+        private BigDecimal initialMarginRate;
+        private BigDecimal maintenanceMarginRate;
+        private String status;
+        private List<String> orderbookGranularities;
+        private Long marketOpenTimestamp;
+        private Long marketCloseTimestamp;
+        private Long marketCreationTimestamp;
+
+        public Builder id(int v) { this.id = v; return this; }
+        public Builder symbol(String v) { this.symbol = v; return this; }
+        public Builder displayName(String v) { this.displayName = v; return this; }
+        public Builder underlyingSymbol(String v) { this.underlyingSymbol = v; return this; }
+        public Builder settlementSymbol(String v) { this.settlementSymbol = v; return this; }
+        public Builder underlyingDecimals(int v) { this.underlyingDecimals = v; return this; }
+        public Builder settlementDecimals(int v) { this.settlementDecimals = v; return this; }
+        public Builder tickSize(BigDecimal v) { this.tickSize = v; return this; }
+        public Builder stepSize(BigDecimal v) { this.stepSize = v; return this; }
+        public Builder minOrderSize(BigDecimal v) { this.minOrderSize = v; return this; }
+        public Builder minNotional(BigDecimal v) { this.minNotional = v; return this; }
+        public Builder initialMarginRate(BigDecimal v) { this.initialMarginRate = v; return this; }
+        public Builder maintenanceMarginRate(BigDecimal v) { this.maintenanceMarginRate = v; return this; }
+        public Builder status(String v) { this.status = v; return this; }
+        public Builder orderbookGranularities(List<String> v) { this.orderbookGranularities = v; return this; }
+        public Builder marketOpenTimestamp(Long v) { this.marketOpenTimestamp = v; return this; }
+        public Builder marketCloseTimestamp(Long v) { this.marketCloseTimestamp = v; return this; }
+        public Builder marketCreationTimestamp(Long v) { this.marketCreationTimestamp = v; return this; }
+
+        public HibachiContract build() { return new HibachiContract(this); }
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/HibachiRestApi.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/HibachiRestApi.java
@@ -133,6 +133,11 @@ public class HibachiRestApi extends BaseRestApi implements IHibachiRestApi {
     }
 
     @Override
+    public JsonNode getMarketStats(String symbol) {
+        return publicRequest(dataBaseUrl, "/market/data/stats", symbolParams(symbol));
+    }
+
+    @Override
     public JsonNode getRecentTrades(String symbol) {
         return publicRequest(dataBaseUrl, "/market/data/trades", symbolParams(symbol));
     }

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/HibachiRestApi.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/HibachiRestApi.java
@@ -1,0 +1,394 @@
+package com.fueledbychai.hibachi.common.api;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fueledbychai.data.Exchange;
+import com.fueledbychai.data.InstrumentDescriptor;
+import com.fueledbychai.data.InstrumentType;
+import com.fueledbychai.http.BaseRestApi;
+import com.fueledbychai.http.OkHttpClientFactory;
+
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * REST client for Hibachi.
+ *
+ * <p>Public market endpoints (e.g. {@code /market/exchange-info}) hit the data-api host;
+ * private trading endpoints (e.g. {@code /trade/account/info}) hit the trading host. The
+ * private auth header is the raw {@code apiKey} value (NOT "Bearer ..."), matching the
+ * Python SDK at {@code executors/httpx.py:130-135}.
+ *
+ * <p>Order place/modify/cancel are intentionally not exposed here — they live on the
+ * trade WebSocket (see the broker module).
+ */
+public class HibachiRestApi extends BaseRestApi implements IHibachiRestApi {
+
+    static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(15L);
+
+    protected final String tradingBaseUrl;
+    protected final String dataBaseUrl;
+    protected final String apiKey;
+    protected final String hibachiClient;
+    protected final boolean publicApiOnly;
+    protected final OkHttpClient client;
+    protected final ObjectMapper objectMapper;
+    protected final Map<String, HibachiContract> contractsBySymbol = new ConcurrentHashMap<>();
+    protected final Map<InstrumentType, InstrumentDescriptor[]> descriptorsByType = new ConcurrentHashMap<>();
+    protected volatile boolean exchangeInfoLoaded;
+
+    public HibachiRestApi(String tradingBaseUrl, String dataBaseUrl, String hibachiClient) {
+        this(tradingBaseUrl, dataBaseUrl, hibachiClient, null);
+    }
+
+    public HibachiRestApi(String tradingBaseUrl, String dataBaseUrl, String hibachiClient, String apiKey) {
+        if (tradingBaseUrl == null || tradingBaseUrl.isBlank()) {
+            throw new IllegalArgumentException("tradingBaseUrl is required");
+        }
+        if (dataBaseUrl == null || dataBaseUrl.isBlank()) {
+            throw new IllegalArgumentException("dataBaseUrl is required");
+        }
+        this.tradingBaseUrl = normalizeBaseUrl(tradingBaseUrl);
+        this.dataBaseUrl = normalizeBaseUrl(dataBaseUrl);
+        this.apiKey = apiKey;
+        this.hibachiClient = hibachiClient == null || hibachiClient.isBlank()
+                ? "FueledByChaiJavaSDK"
+                : hibachiClient;
+        this.publicApiOnly = apiKey == null || apiKey.isBlank();
+        this.client = OkHttpClientFactory.create(REQUEST_TIMEOUT);
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public InstrumentDescriptor[] getAllInstrumentsForType(InstrumentType instrumentType) {
+        if (instrumentType != InstrumentType.PERPETUAL_FUTURES) {
+            return new InstrumentDescriptor[0];
+        }
+        ensureExchangeInfoLoaded();
+        InstrumentDescriptor[] cached = descriptorsByType.get(instrumentType);
+        return cached == null ? new InstrumentDescriptor[0] : cached;
+    }
+
+    @Override
+    public InstrumentDescriptor getInstrumentDescriptor(String symbol) {
+        if (symbol == null || symbol.isBlank()) {
+            return null;
+        }
+        ensureExchangeInfoLoaded();
+        String normalized = symbol.trim().toUpperCase(Locale.US);
+        for (InstrumentDescriptor descriptor : getAllInstrumentsForType(InstrumentType.PERPETUAL_FUTURES)) {
+            if (normalized.equalsIgnoreCase(descriptor.getExchangeSymbol())
+                    || normalized.equalsIgnoreCase(descriptor.getCommonSymbol())) {
+                return descriptor;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public HibachiContract getContract(String symbol) {
+        if (symbol == null || symbol.isBlank()) {
+            return null;
+        }
+        ensureExchangeInfoLoaded();
+        return contractsBySymbol.get(symbol.trim().toUpperCase(Locale.US));
+    }
+
+    @Override
+    public Map<String, HibachiContract> getAllContracts() {
+        ensureExchangeInfoLoaded();
+        return Collections.unmodifiableMap(contractsBySymbol);
+    }
+
+    @Override
+    public boolean isPublicApiOnly() {
+        return publicApiOnly;
+    }
+
+    @Override
+    public Date getServerTime() {
+        JsonNode root = publicRequest(tradingBaseUrl, "/exchange/utc-timestamp", null);
+        long ts = root.path("utcTimestamp").asLong(System.currentTimeMillis());
+        // Field may be in seconds or millis depending on API version; treat values < 1e12 as seconds.
+        return new Date(ts < 1_000_000_000_000L ? ts * 1000L : ts);
+    }
+
+    @Override
+    public JsonNode getMarketStats() {
+        return publicRequest(dataBaseUrl, "/market/data/stats", null);
+    }
+
+    @Override
+    public JsonNode getRecentTrades(String symbol) {
+        return publicRequest(dataBaseUrl, "/market/data/trades", symbolParams(symbol));
+    }
+
+    @Override
+    public JsonNode getOrderBookSnapshot(String symbol) {
+        return publicRequest(dataBaseUrl, "/market/data/orderbook", symbolParams(symbol));
+    }
+
+    @Override
+    public JsonNode getKlines(String symbol, String interval, Integer limit) {
+        Map<String, String> params = new LinkedHashMap<>();
+        if (symbol != null) params.put("symbol", symbol);
+        if (interval != null) params.put("interval", interval);
+        if (limit != null) params.put("limit", limit.toString());
+        return publicRequest(dataBaseUrl, "/market/data/klines", params);
+    }
+
+    @Override
+    public JsonNode getOpenInterest(String symbol) {
+        return publicRequest(dataBaseUrl, "/market/data/open-interest", symbolParams(symbol));
+    }
+
+    @Override
+    public JsonNode getFundingRates(String symbol) {
+        return publicRequest(dataBaseUrl, "/market/data/funding-rates", symbolParams(symbol));
+    }
+
+    @Override
+    public JsonNode getPrices() {
+        return publicRequest(dataBaseUrl, "/market/data/prices", null);
+    }
+
+    @Override
+    public JsonNode getTradeAccountInfo() {
+        requirePrivateApi();
+        return privateRequest(tradingBaseUrl, "/trade/account/info", null);
+    }
+
+    @Override
+    public JsonNode getAccountTrades() {
+        requirePrivateApi();
+        return privateRequest(tradingBaseUrl, "/trade/account/trades", null);
+    }
+
+    @Override
+    public JsonNode getOpenOrders() {
+        requirePrivateApi();
+        return privateRequest(tradingBaseUrl, "/trade/orders", null);
+    }
+
+    @Override
+    public JsonNode getOrder(String orderId) {
+        requirePrivateApi();
+        if (orderId == null || orderId.isBlank()) {
+            throw new IllegalArgumentException("orderId is required");
+        }
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("orderId", orderId);
+        return privateRequest(tradingBaseUrl, "/trade/order", params);
+    }
+
+    @Override
+    public JsonNode getCapitalBalance() {
+        requirePrivateApi();
+        return privateRequest(tradingBaseUrl, "/capital/balance", null);
+    }
+
+    // ---------- internals ----------
+
+    protected void ensureExchangeInfoLoaded() {
+        if (exchangeInfoLoaded) {
+            return;
+        }
+        synchronized (contractsBySymbol) {
+            if (exchangeInfoLoaded) {
+                return;
+            }
+            JsonNode root = publicRequest(dataBaseUrl, "/market/exchange-info", null);
+            List<InstrumentDescriptor> descriptors = new ArrayList<>();
+            JsonNode contractsNode = root.has("futureContracts") ? root.path("futureContracts") : root.path("contracts");
+            for (JsonNode node : contractsNode) {
+                HibachiContract contract = parseContract(node);
+                if (contract == null) {
+                    continue;
+                }
+                contractsBySymbol.put(contract.getSymbol().toUpperCase(Locale.US), contract);
+                InstrumentDescriptor descriptor = toDescriptor(contract);
+                if (descriptor != null) {
+                    descriptors.add(descriptor);
+                }
+            }
+            descriptorsByType.put(InstrumentType.PERPETUAL_FUTURES,
+                    descriptors.toArray(new InstrumentDescriptor[0]));
+            exchangeInfoLoaded = true;
+        }
+    }
+
+    protected HibachiContract parseContract(JsonNode node) {
+        if (node == null || !node.has("symbol") || !node.has("id")) {
+            return null;
+        }
+        HibachiContract.Builder b = HibachiContract.builder()
+                .id(node.path("id").asInt())
+                .symbol(node.path("symbol").asText())
+                .displayName(node.path("displayName").asText(null))
+                .underlyingSymbol(node.path("underlyingSymbol").asText(null))
+                .settlementSymbol(node.path("settlementSymbol").asText(null))
+                .underlyingDecimals(node.path("underlyingDecimals").asInt())
+                .settlementDecimals(node.path("settlementDecimals").asInt())
+                .tickSize(decimal(node, "tickSize"))
+                .stepSize(decimal(node, "stepSize"))
+                .minOrderSize(decimal(node, "minOrderSize"))
+                .minNotional(decimal(node, "minNotional"))
+                .initialMarginRate(decimal(node, "initialMarginRate"))
+                .maintenanceMarginRate(decimal(node, "maintenanceMarginRate"))
+                .status(node.path("status").asText(null));
+        if (node.has("orderbookGranularities")) {
+            List<String> granularities = new ArrayList<>();
+            node.path("orderbookGranularities").forEach(g -> granularities.add(g.asText()));
+            b.orderbookGranularities(granularities);
+        }
+        b.marketOpenTimestamp(longOrNull(node, "marketOpenTimestamp"));
+        b.marketCloseTimestamp(longOrNull(node, "marketCloseTimestamp"));
+        b.marketCreationTimestamp(longOrNull(node, "marketCreationTimestamp"));
+        return b.build();
+    }
+
+    protected InstrumentDescriptor toDescriptor(HibachiContract contract) {
+        if (contract == null) {
+            return null;
+        }
+        // Hibachi symbol "BTC/USDT-P" — splits into base "BTC" / quote "USDT".
+        String symbol = contract.getSymbol();
+        String base = contract.getUnderlyingSymbol();
+        String quote = contract.getSettlementSymbol();
+        if (base == null || quote == null) {
+            int slash = symbol.indexOf('/');
+            int dash = symbol.indexOf('-');
+            if (slash > 0 && dash > slash) {
+                base = symbol.substring(0, slash);
+                quote = symbol.substring(slash + 1, dash);
+            } else {
+                return null;
+            }
+        }
+        BigDecimal tickSize = contract.getTickSize() != null ? contract.getTickSize() : BigDecimal.ONE;
+        BigDecimal stepSize = contract.getStepSize() != null ? contract.getStepSize() : BigDecimal.ONE;
+        BigDecimal minOrderSize = contract.getMinOrderSize() != null ? contract.getMinOrderSize() : BigDecimal.ONE;
+        int minNotional = contract.getMinNotional() == null
+                ? 1
+                : contract.getMinNotional().max(BigDecimal.ONE).intValue();
+        return new InstrumentDescriptor(
+                InstrumentType.PERPETUAL_FUTURES,
+                Exchange.HIBACHI,
+                symbol, // commonSymbol — already canonical
+                symbol, // exchangeSymbol — same
+                base,
+                quote,
+                stepSize,
+                tickSize,
+                minNotional,
+                minOrderSize,
+                8,
+                BigDecimal.ONE,
+                1,
+                Integer.toString(contract.getId()));
+    }
+
+    protected JsonNode publicRequest(String baseUrl, String path, Map<String, String> params) {
+        HttpUrl url = buildUrl(baseUrl, path, params);
+        Request.Builder builder = new Request.Builder()
+                .url(url)
+                .get()
+                .addHeader("Hibachi-Client", hibachiClient)
+                .addHeader("Accept", "application/json");
+        return execute(builder.build());
+    }
+
+    protected JsonNode privateRequest(String baseUrl, String path, Map<String, String> params) {
+        HttpUrl url = buildUrl(baseUrl, path, params);
+        Request.Builder builder = new Request.Builder()
+                .url(url)
+                .get()
+                .addHeader("Authorization", apiKey)
+                .addHeader("Hibachi-Client", hibachiClient)
+                .addHeader("Accept", "application/json");
+        return execute(builder.build());
+    }
+
+    protected HttpUrl buildUrl(String baseUrl, String path, Map<String, String> params) {
+        HttpUrl.Builder b = HttpUrl.parse(baseUrl + path).newBuilder();
+        if (params != null) {
+            for (Map.Entry<String, String> e : params.entrySet()) {
+                if (e.getKey() != null && e.getValue() != null) {
+                    b.addQueryParameter(e.getKey(), e.getValue());
+                }
+            }
+        }
+        return b.build();
+    }
+
+    protected JsonNode execute(Request request) {
+        try (Response response = client.newCall(request).execute()) {
+            String body = response.body() == null ? "" : response.body().string();
+            if (!response.isSuccessful()) {
+                throw new IllegalStateException("Hibachi request failed with HTTP " + response.code() + ": " + body);
+            }
+            if (body.isBlank()) {
+                return objectMapper.createObjectNode();
+            }
+            return objectMapper.readTree(body);
+        } catch (IOException e) {
+            throw new RuntimeException("Hibachi request failed: " + e.getMessage(), e);
+        }
+    }
+
+    protected Map<String, String> symbolParams(String symbol) {
+        if (symbol == null || symbol.isBlank()) {
+            return null;
+        }
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("symbol", symbol);
+        return params;
+    }
+
+    protected void requirePrivateApi() {
+        if (publicApiOnly) {
+            throw new IllegalStateException("Hibachi private API requires apiKey configuration");
+        }
+    }
+
+    protected String normalizeBaseUrl(String url) {
+        String trimmed = url.trim();
+        return trimmed.endsWith("/") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
+    }
+
+    private static BigDecimal decimal(JsonNode node, String field) {
+        if (node == null || !node.has(field)) {
+            return null;
+        }
+        String text = node.path(field).asText("");
+        if (text.isBlank()) {
+            return null;
+        }
+        try {
+            return new BigDecimal(text);
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static Long longOrNull(JsonNode node, String field) {
+        if (node == null || !node.has(field) || node.path(field).isNull()) {
+            return null;
+        }
+        return node.path(field).asLong();
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/HibachiRestApiProvider.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/HibachiRestApiProvider.java
@@ -1,0 +1,48 @@
+package com.fueledbychai.hibachi.common.api;
+
+import com.fueledbychai.data.Exchange;
+import com.fueledbychai.util.ExchangeRestApiProvider;
+
+public class HibachiRestApiProvider implements ExchangeRestApiProvider<IHibachiRestApi> {
+
+    @Override
+    public Exchange getExchange() {
+        return Exchange.HIBACHI;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Class<IHibachiRestApi> getApiType() {
+        return (Class<IHibachiRestApi>) (Class<?>) IHibachiRestApi.class;
+    }
+
+    @Override
+    public IHibachiRestApi getPublicApi() {
+        HibachiConfiguration config = HibachiConfiguration.getInstance();
+        return new HibachiRestApi(config.getRestUrl(), config.getDataRestUrl(), config.getClient());
+    }
+
+    @Override
+    public IHibachiRestApi getApi() {
+        return isPrivateApiAvailable() ? getPrivateApi() : getPublicApi();
+    }
+
+    @Override
+    public boolean isPrivateApiAvailable() {
+        return HibachiConfiguration.getInstance().hasPrivateApiConfiguration();
+    }
+
+    @Override
+    public IHibachiRestApi getPrivateApi() {
+        HibachiConfiguration config = HibachiConfiguration.getInstance();
+        if (!config.hasPrivateApiConfiguration()) {
+            throw new IllegalStateException(
+                    "Hibachi private API requires "
+                            + HibachiConfiguration.HIBACHI_API_KEY + ", "
+                            + HibachiConfiguration.HIBACHI_API_SECRET + ", "
+                            + HibachiConfiguration.HIBACHI_ACCOUNT_ID + " configuration.");
+        }
+        return new HibachiRestApi(config.getRestUrl(), config.getDataRestUrl(), config.getClient(),
+                config.getApiKey());
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/IHibachiRestApi.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/IHibachiRestApi.java
@@ -42,6 +42,9 @@ public interface IHibachiRestApi {
     /** Top-of-book and ticker stats per symbol. */
     JsonNode getMarketStats();
 
+    /** 24h stats (high, low, volume) for a single symbol. */
+    JsonNode getMarketStats(String symbol);
+
     /** Recent trades for a symbol. */
     JsonNode getRecentTrades(String symbol);
 

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/IHibachiRestApi.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/IHibachiRestApi.java
@@ -1,0 +1,79 @@
+package com.fueledbychai.hibachi.common.api;
+
+import java.util.Date;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fueledbychai.data.InstrumentDescriptor;
+import com.fueledbychai.data.InstrumentType;
+
+/**
+ * Public + private REST contract for the Hibachi exchange.
+ *
+ * <p>Public market endpoints live on {@code https://data-api.hibachi.xyz}; private trading
+ * endpoints live on {@code https://api.hibachi.xyz}. Order place/modify/cancel are NOT on
+ * the REST surface — they are sent over the trade WebSocket. See the broker module.
+ */
+public interface IHibachiRestApi {
+
+    /** Returns known instrument descriptors for the requested instrument type. */
+    InstrumentDescriptor[] getAllInstrumentsForType(InstrumentType instrumentType);
+
+    /** Resolves a single instrument descriptor by exchange or common symbol. */
+    InstrumentDescriptor getInstrumentDescriptor(String symbol);
+
+    /**
+     * Returns the {@link HibachiContract} for a symbol — required by the trade-WS signer
+     * for {@code contractId} and decimal scales.
+     */
+    HibachiContract getContract(String symbol);
+
+    /** Returns all {@link HibachiContract}s by symbol. */
+    Map<String, HibachiContract> getAllContracts();
+
+    /** Indicates whether this API instance was created without private credentials. */
+    boolean isPublicApiOnly();
+
+    /** Exchange UTC server time. */
+    Date getServerTime();
+
+    // ---------- public market data ----------
+
+    /** Top-of-book and ticker stats per symbol. */
+    JsonNode getMarketStats();
+
+    /** Recent trades for a symbol. */
+    JsonNode getRecentTrades(String symbol);
+
+    /** Order book snapshot for a symbol. */
+    JsonNode getOrderBookSnapshot(String symbol);
+
+    /** Historical klines for a symbol. */
+    JsonNode getKlines(String symbol, String interval, Integer limit);
+
+    /** Open interest for a symbol. */
+    JsonNode getOpenInterest(String symbol);
+
+    /** Funding rates for a symbol. */
+    JsonNode getFundingRates(String symbol);
+
+    /** Mark-price + spot-price snapshot. */
+    JsonNode getPrices();
+
+    // ---------- private trading ----------
+
+    /** Account information (balance, positions, margin). */
+    JsonNode getTradeAccountInfo();
+
+    /** Recent trades for the authenticated account. */
+    JsonNode getAccountTrades();
+
+    /** Open orders for the authenticated account. */
+    JsonNode getOpenOrders();
+
+    /** Single order by id. */
+    JsonNode getOrder(String orderId);
+
+    /** Capital balance (deposits/withdrawals). */
+    JsonNode getCapitalBalance();
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/order/HibachiOrderFlag.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/order/HibachiOrderFlag.java
@@ -1,0 +1,18 @@
+package com.fueledbychai.hibachi.common.api.order;
+
+public enum HibachiOrderFlag {
+
+    POST_ONLY("POST_ONLY"),
+    IOC("IOC"),
+    REDUCE_ONLY("REDUCE_ONLY");
+
+    private final String wireValue;
+
+    HibachiOrderFlag(String wireValue) {
+        this.wireValue = wireValue;
+    }
+
+    public String getWireValue() {
+        return wireValue;
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/order/HibachiOrderType.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/order/HibachiOrderType.java
@@ -1,0 +1,17 @@
+package com.fueledbychai.hibachi.common.api.order;
+
+public enum HibachiOrderType {
+
+    LIMIT("LIMIT"),
+    MARKET("MARKET");
+
+    private final String wireValue;
+
+    HibachiOrderType(String wireValue) {
+        this.wireValue = wireValue;
+    }
+
+    public String getWireValue() {
+        return wireValue;
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/order/HibachiSide.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/order/HibachiSide.java
@@ -1,0 +1,47 @@
+package com.fueledbychai.hibachi.common.api.order;
+
+/**
+ * Hibachi order side.
+ *
+ * <p>Wire values BID/ASK — BUY normalizes to BID, SELL normalizes to ASK (matches the
+ * Python SDK behaviour at api.py:1286-1289, 1388-1391, 1657-1660).
+ *
+ * <p>Byte encoding in signed payloads is u32 big-endian: ASK=0, BID=1.
+ */
+public enum HibachiSide {
+
+    BID("BID", 1),
+    ASK("ASK", 0);
+
+    private final String wireValue;
+    private final int byteValue;
+
+    HibachiSide(String wireValue, int byteValue) {
+        this.wireValue = wireValue;
+        this.byteValue = byteValue;
+    }
+
+    public String getWireValue() {
+        return wireValue;
+    }
+
+    public int getByteValue() {
+        return byteValue;
+    }
+
+    public static HibachiSide fromWireValue(String wire) {
+        if (wire == null) {
+            throw new IllegalArgumentException("wire value is null");
+        }
+        switch (wire.trim().toUpperCase()) {
+            case "BID":
+            case "BUY":
+                return BID;
+            case "ASK":
+            case "SELL":
+                return ASK;
+            default:
+                throw new IllegalArgumentException("Unknown Hibachi side: " + wire);
+        }
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/signer/HibachiPayloadPacker.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/signer/HibachiPayloadPacker.java
@@ -1,0 +1,153 @@
+package com.fueledbychai.hibachi.common.api.signer;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import com.fueledbychai.hibachi.common.api.HibachiContract;
+import com.fueledbychai.hibachi.common.api.order.HibachiSide;
+
+/**
+ * Assembles the raw binary payloads that Hibachi signs.
+ *
+ * <p>All fields are big-endian. Layout ported from the Python SDK at
+ * {@code hibachi_xyz/api.py:__create_or_update_order_payload} (api.py:1989-2039) and
+ * {@code __cancel_order_payload} (api.py:2173-2193).
+ *
+ * <h2>Place / Modify order (identical bytes)</h2>
+ * <ol>
+ *   <li>{@code nonce} — 8 bytes (u64 BE)</li>
+ *   <li>{@code contractId} — 4 bytes (u32 BE)</li>
+ *   <li>{@code quantity} scaled — 8 bytes (u64 BE) = {@code int(quantity * 10^underlyingDecimals)}</li>
+ *   <li>{@code side} — 4 bytes (u32 BE): ASK=0, BID=1</li>
+ *   <li>{@code price} scaled — 8 bytes (u64 BE) = {@code int(price * 2^32 * 10^(settlementDecimals - underlyingDecimals))}.
+ *       <b>Omitted entirely for MARKET orders</b> (not zero-padded).</li>
+ *   <li>{@code maxFeesPercent} scaled — 8 bytes (u64 BE) = {@code int(maxFeesPercent * 10^8)}. Scale is hard-coded 1e8.</li>
+ * </ol>
+ *
+ * <p>Limit payload = 40 bytes. Market payload = 32 bytes.
+ *
+ * <h2>Cancel order</h2>
+ * <p>8 bytes, either {@code orderId} or {@code nonce} (u64 BE). No tag byte — the server
+ * distinguishes by the JSON envelope.
+ *
+ * <p><b>{@code triggerPrice}, {@code triggerDirection}, {@code creationDeadline},
+ * {@code orderFlags}, {@code twapConfig}, and {@code parentOrder} are NEVER in the signed bytes</b>
+ * — they are only JSON envelope fields. See api.py:2099-2110.
+ */
+public final class HibachiPayloadPacker {
+
+    private static final BigDecimal POW_2_32 = new BigDecimal(BigInteger.ONE.shiftLeft(32));
+    private static final BigDecimal MAX_FEES_SCALE = new BigDecimal(BigInteger.TEN.pow(8));
+
+    private HibachiPayloadPacker() {
+    }
+
+    /**
+     * Packs a place- or modify-order payload.
+     *
+     * @param nonce          strictly monotonic per account
+     * @param contract       from {@code /market/exchange-info}
+     * @param quantity       base quantity (scaled by underlyingDecimals)
+     * @param side           BID or ASK
+     * @param price          limit price; {@code null} for MARKET orders (price bytes are omitted)
+     * @param maxFeesPercent max fees as a percent (e.g. 0.5 for 0.5%); scaled by 1e8
+     * @return packed bytes (40 if price != null, else 32)
+     */
+    public static byte[] packPlaceOrder(long nonce,
+                                        HibachiContract contract,
+                                        BigDecimal quantity,
+                                        HibachiSide side,
+                                        BigDecimal price,
+                                        BigDecimal maxFeesPercent) {
+        if (contract == null) throw new IllegalArgumentException("contract is required");
+        if (quantity == null) throw new IllegalArgumentException("quantity is required");
+        if (side == null) throw new IllegalArgumentException("side is required");
+        if (maxFeesPercent == null) throw new IllegalArgumentException("maxFeesPercent is required");
+
+        long quantityScaled = scaleQuantity(quantity, contract);
+        long maxFeesScaled = scaleMaxFeesPercent(maxFeesPercent);
+        Long priceScaled = price == null ? null : scalePrice(price, contract);
+
+        int size = priceScaled == null ? 32 : 40;
+        ByteBuffer buf = ByteBuffer.allocate(size).order(ByteOrder.BIG_ENDIAN);
+        buf.putLong(nonce);
+        buf.putInt(contract.getId());
+        buf.putLong(quantityScaled);
+        buf.putInt(side.getByteValue());
+        if (priceScaled != null) {
+            buf.putLong(priceScaled);
+        }
+        buf.putLong(maxFeesScaled);
+        return buf.array();
+    }
+
+    /**
+     * Packs a cancel-order payload.
+     *
+     * <p>8 bytes, either {@code orderId} or {@code nonce}. If both are non-null, {@code orderId}
+     * takes precedence (matches Python SDK precedence at api.py:2173-2193).
+     */
+    public static byte[] packCancelOrder(Long orderId, Long nonce) {
+        long value;
+        if (orderId != null) {
+            value = orderId;
+        } else if (nonce != null) {
+            value = nonce;
+        } else {
+            throw new IllegalArgumentException("either orderId or nonce must be provided");
+        }
+        return ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(value).array();
+    }
+
+    /**
+     * Packs a cancel-all (orders.cancel) payload — 8-byte big-endian nonce.
+     */
+    public static byte[] packCancelAll(long nonce) {
+        return ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(nonce).array();
+    }
+
+    /**
+     * Scales quantity: {@code int(quantity * 10^underlyingDecimals)}, truncating toward zero.
+     * Matches api.py:2017-2019.
+     */
+    public static long scaleQuantity(BigDecimal quantity, HibachiContract contract) {
+        BigDecimal multiplier = BigDecimal.TEN.pow(contract.getUnderlyingDecimals());
+        BigDecimal scaled = quantity.multiply(multiplier);
+        return toLongTruncating(scaled, "quantity");
+    }
+
+    /**
+     * Scales price: {@code int(price * 2^32 * 10^(settlementDecimals - underlyingDecimals))},
+     * truncating toward zero. Matches api.py:211-229 ({@code price_to_bytes}).
+     */
+    public static long scalePrice(BigDecimal price, HibachiContract contract) {
+        int decimalDelta = contract.getSettlementDecimals() - contract.getUnderlyingDecimals();
+        BigDecimal decimalShift;
+        if (decimalDelta >= 0) {
+            decimalShift = BigDecimal.TEN.pow(decimalDelta);
+        } else {
+            decimalShift = BigDecimal.ONE.divide(BigDecimal.TEN.pow(-decimalDelta));
+        }
+        BigDecimal scaled = price.multiply(POW_2_32).multiply(decimalShift);
+        return toLongTruncating(scaled, "price");
+    }
+
+    /**
+     * Scales max-fees-percent: {@code int(maxFeesPercent * 10^8)}, truncating toward zero.
+     * Matches api.py:2020-2022 — the 1e8 scale is hard-coded, NOT derived from the contract.
+     */
+    public static long scaleMaxFeesPercent(BigDecimal maxFeesPercent) {
+        return toLongTruncating(maxFeesPercent.multiply(MAX_FEES_SCALE), "maxFeesPercent");
+    }
+
+    private static long toLongTruncating(BigDecimal value, String field) {
+        BigInteger asInt = value.setScale(0, RoundingMode.DOWN).toBigInteger();
+        if (asInt.bitLength() > 63) {
+            throw new IllegalArgumentException(field + " overflows 64-bit signed: " + asInt);
+        }
+        return asInt.longValueExact();
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/signer/HibachiSignerFactory.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/signer/HibachiSignerFactory.java
@@ -1,0 +1,22 @@
+package com.fueledbychai.hibachi.common.api.signer;
+
+import com.fueledbychai.hibachi.common.api.HibachiConfiguration;
+
+public final class HibachiSignerFactory {
+
+    private HibachiSignerFactory() {
+    }
+
+    public static IHibachiSigner create() {
+        return create(HibachiConfiguration.getInstance());
+    }
+
+    public static IHibachiSigner create(HibachiConfiguration config) {
+        String secret = config.getApiSecret();
+        if (secret == null || secret.isBlank()) {
+            throw new IllegalStateException(
+                    "Cannot create Hibachi signer: " + HibachiConfiguration.HIBACHI_API_SECRET + " is not configured");
+        }
+        return new HmacHibachiSigner(secret);
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/signer/HmacHibachiSigner.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/signer/HmacHibachiSigner.java
@@ -1,0 +1,59 @@
+package com.fueledbychai.hibachi.common.api.signer;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * HMAC-SHA256 Hibachi signer.
+ *
+ * <p>Key is the raw UTF-8 bytes of the apiSecret string (do not hex-decode, do not base64-decode).
+ * Message is the raw packed payload (not pre-hashed). Output is lowercase hex (64 chars).
+ * Matches {@code hibachi_xyz/api.py:__sign_payload} (api.py:1950-1987).
+ */
+public class HmacHibachiSigner implements IHibachiSigner {
+
+    private static final String HMAC_ALGO = "HmacSHA256";
+    private static final char[] HEX_LOWER = "0123456789abcdef".toCharArray();
+
+    private final byte[] keyBytes;
+
+    public HmacHibachiSigner(String apiSecret) {
+        if (apiSecret == null || apiSecret.isEmpty()) {
+            throw new IllegalArgumentException("apiSecret is required");
+        }
+        this.keyBytes = apiSecret.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public String sign(byte[] packedPayload) {
+        if (packedPayload == null) {
+            throw new IllegalArgumentException("packedPayload is required");
+        }
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGO);
+            mac.init(new SecretKeySpec(keyBytes, HMAC_ALGO));
+            return toHexLower(mac.doFinal(packedPayload));
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new IllegalStateException("HMAC-SHA256 unavailable", e);
+        }
+    }
+
+    @Override
+    public SignatureScheme scheme() {
+        return SignatureScheme.HMAC_SHA256;
+    }
+
+    private static String toHexLower(byte[] bytes) {
+        char[] out = new char[bytes.length * 2];
+        for (int i = 0; i < bytes.length; i++) {
+            int v = bytes[i] & 0xFF;
+            out[i * 2] = HEX_LOWER[v >>> 4];
+            out[i * 2 + 1] = HEX_LOWER[v & 0x0F];
+        }
+        return new String(out);
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/signer/IHibachiSigner.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/signer/IHibachiSigner.java
@@ -1,0 +1,21 @@
+package com.fueledbychai.hibachi.common.api.signer;
+
+/**
+ * Pluggable signer for Hibachi order payloads.
+ *
+ * <p>v1 ships with {@link HmacHibachiSigner} (HMAC-SHA256 over the packed binary payload).
+ * ECDSA (trustless) accounts are a future follow-up — add a sibling implementation and
+ * select via {@link HibachiSignerFactory}.
+ */
+public interface IHibachiSigner {
+
+    /**
+     * Signs a raw packed payload.
+     *
+     * @param packedPayload bytes assembled by {@link HibachiPayloadPacker} (big-endian)
+     * @return the hex-encoded signature string to place in the Hibachi JSON envelope
+     */
+    String sign(byte[] packedPayload);
+
+    SignatureScheme scheme();
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/signer/SignatureScheme.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/signer/SignatureScheme.java
@@ -1,0 +1,6 @@
+package com.fueledbychai.hibachi.common.api.signer;
+
+public enum SignatureScheme {
+    HMAC_SHA256,
+    ECDSA
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/HibachiJsonProcessor.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/HibachiJsonProcessor.java
@@ -1,0 +1,32 @@
+package com.fueledbychai.hibachi.common.api.ws;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fueledbychai.websocket.AbstractWebSocketProcessor;
+import com.fueledbychai.websocket.IWebSocketClosedListener;
+
+/**
+ * Generic JSON-parsing processor for Hibachi WebSocket frames.
+ *
+ * <p>Subclasses or downstream consumers receive the parsed {@link JsonNode}; topic
+ * routing is the listener's responsibility (or can be done via {@link HibachiTopicRouter}).
+ */
+public class HibachiJsonProcessor extends AbstractWebSocketProcessor<JsonNode> {
+
+    protected final ObjectMapper objectMapper = new ObjectMapper();
+
+    public HibachiJsonProcessor(IWebSocketClosedListener listener) {
+        super(listener);
+    }
+
+    @Override
+    protected JsonNode parseMessage(String message) {
+        try {
+            JsonNode root = objectMapper.readTree(message);
+            return root == null || root.isNull() ? null : root;
+        } catch (Exception e) {
+            logger.debug("Ignoring malformed Hibachi WebSocket payload: {}", message, e);
+            return null;
+        }
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/HibachiMarketSubscribeMessage.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/HibachiMarketSubscribeMessage.java
@@ -1,0 +1,79 @@
+package com.fueledbychai.hibachi.common.api.ws;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Builder for Hibachi market WebSocket subscribe / unsubscribe messages.
+ *
+ * <p>Note the outer key is {@code "parameters"} (not {@code "params"}) — this is unique to
+ * the market WS. See {@code hibachi_xyz/api_ws_market.py:95-129} in the Python SDK.
+ *
+ * <p>Example output:
+ * <pre>
+ * {"method":"subscribe","parameters":{"subscriptions":[{"symbol":"BTC/USDT-P","topic":"mark_price"}]}}
+ * </pre>
+ */
+public final class HibachiMarketSubscribeMessage {
+
+    public static final String METHOD_SUBSCRIBE = "subscribe";
+    public static final String METHOD_UNSUBSCRIBE = "unsubscribe";
+
+    private HibachiMarketSubscribeMessage() {
+    }
+
+    public static String subscribe(String symbol, String topic) {
+        return build(METHOD_SUBSCRIBE, List.of(new Subscription(symbol, topic)));
+    }
+
+    public static String subscribe(Collection<Subscription> subscriptions) {
+        return build(METHOD_SUBSCRIBE, subscriptions);
+    }
+
+    public static String unsubscribe(String symbol, String topic) {
+        return build(METHOD_UNSUBSCRIBE, List.of(new Subscription(symbol, topic)));
+    }
+
+    public static String unsubscribe(Collection<Subscription> subscriptions) {
+        return build(METHOD_UNSUBSCRIBE, subscriptions);
+    }
+
+    private static String build(String method, Collection<Subscription> subscriptions) {
+        if (subscriptions == null || subscriptions.isEmpty()) {
+            throw new IllegalArgumentException("subscriptions must be non-empty");
+        }
+        JSONArray subs = new JSONArray();
+        for (Subscription s : new ArrayList<>(subscriptions)) {
+            JSONObject sub = new JSONObject();
+            sub.put("symbol", s.symbol);
+            sub.put("topic", s.topic);
+            subs.put(sub);
+        }
+        JSONObject parameters = new JSONObject();
+        parameters.put("subscriptions", subs);
+        JSONObject root = new JSONObject();
+        root.put("method", method);
+        root.put("parameters", parameters);
+        return root.toString();
+    }
+
+    public static final class Subscription {
+        public final String symbol;
+        public final String topic;
+
+        public Subscription(String symbol, String topic) {
+            if (symbol == null || symbol.isBlank()) {
+                throw new IllegalArgumentException("symbol is required");
+            }
+            if (topic == null || topic.isBlank()) {
+                throw new IllegalArgumentException("topic is required");
+            }
+            this.symbol = symbol;
+            this.topic = topic;
+        }
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/HibachiTopicRouter.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/HibachiTopicRouter.java
@@ -16,7 +16,10 @@ public final class HibachiTopicRouter {
     public static final String TOPIC_ASK_BID_PRICE = "ask_bid_price";
 
     /** Topics that compose the framework's Level1 snapshot for Hibachi. */
-    public static final String[] LEVEL1_TOPICS = { TOPIC_ASK_BID_PRICE, TOPIC_MARK_PRICE };
+    public static final String[] LEVEL1_TOPICS = {
+            TOPIC_ASK_BID_PRICE, TOPIC_MARK_PRICE,
+            TOPIC_FUNDING_RATE_ESTIMATION, TOPIC_TRADES
+    };
 
     /** Topic that drives the framework's Level2 (order book) feed. */
     public static final String LEVEL2_TOPIC = TOPIC_ORDERBOOK;

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/HibachiTopicRouter.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/HibachiTopicRouter.java
@@ -1,0 +1,29 @@
+package com.fueledbychai.hibachi.common.api.ws;
+
+/**
+ * Hibachi market WebSocket topic identifiers.
+ *
+ * <p>Wire values match the Python SDK at {@code hibachi_xyz/types.py:163-172}.
+ */
+public final class HibachiTopicRouter {
+
+    public static final String TOPIC_MARK_PRICE = "mark_price";
+    public static final String TOPIC_SPOT_PRICE = "spot_price";
+    public static final String TOPIC_FUNDING_RATE_ESTIMATION = "funding_rate_estimation";
+    public static final String TOPIC_TRADES = "trades";
+    public static final String TOPIC_KLINES = "klines";
+    public static final String TOPIC_ORDERBOOK = "orderbook";
+    public static final String TOPIC_ASK_BID_PRICE = "ask_bid_price";
+
+    /** Topics that compose the framework's Level1 snapshot for Hibachi. */
+    public static final String[] LEVEL1_TOPICS = { TOPIC_ASK_BID_PRICE, TOPIC_MARK_PRICE };
+
+    /** Topic that drives the framework's Level2 (order book) feed. */
+    public static final String LEVEL2_TOPIC = TOPIC_ORDERBOOK;
+
+    /** Topic that drives the framework's order-flow (time and sales) feed. */
+    public static final String ORDER_FLOW_TOPIC = TOPIC_TRADES;
+
+    private HibachiTopicRouter() {
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/HibachiWebSocketClient.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/HibachiWebSocketClient.java
@@ -40,6 +40,9 @@ public class HibachiWebSocketClient extends AbstractWebSocketClient {
         for (Map.Entry<String, String> e : headers.entrySet()) {
             super.addHeader(e.getKey(), e.getValue());
         }
+        // Hibachi's public stream does not reliably satisfy Java-WebSocket's
+        // lost-pong watchdog, which closes the socket after ~60s of no pong.
+        setConnectionLostTimeout(0);
     }
 
     public static HibachiWebSocketClient createMarket(String serverUri,
@@ -60,10 +63,18 @@ public class HibachiWebSocketClient extends AbstractWebSocketClient {
 
     @Override
     public void onOpen(ServerHandshake handshakedata) {
+        logger.info("Hibachi WS onOpen status={} message={}",
+                handshakedata.getHttpStatus(), handshakedata.getHttpStatusMessage());
         processor.connectionOpened();
         if (subscribeMessage != null && !subscribeMessage.isBlank()) {
             send(subscribeMessage);
         }
+    }
+
+    @Override
+    public void onMessage(String message) {
+        logger.debug("Hibachi WS raw recv: {}", message);
+        super.onMessage(message);
     }
 
     @Override
@@ -72,6 +83,12 @@ public class HibachiWebSocketClient extends AbstractWebSocketClient {
         if (processor != null) {
             processor.connectionError(ex);
         }
+    }
+
+    @Override
+    public void onClose(int code, String reason, boolean remote) {
+        logger.info("Hibachi WS onClose code={} remote={} reason={}", code, remote, reason);
+        super.onClose(code, reason, remote);
     }
 
     private static URI buildUri(String serverUri, String hibachiClient) {

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/HibachiWebSocketClient.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/HibachiWebSocketClient.java
@@ -1,0 +1,94 @@
+package com.fueledbychai.hibachi.common.api.ws;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.java_websocket.handshake.ServerHandshake;
+
+import com.fueledbychai.websocket.AbstractWebSocketClient;
+import com.fueledbychai.websocket.IWebSocketProcessor;
+
+/**
+ * WebSocket client for Hibachi market / account / trade streams.
+ *
+ * <p>Private streams (account + trade) require an {@code Authorization: <apiKey>} handshake
+ * header (raw value, not "Bearer") and an {@code accountId} URL query parameter. Market
+ * stream is anonymous.
+ *
+ * <p>If a non-blank {@code subscribeMessage} is supplied, it is sent immediately after
+ * connection open.
+ */
+public class HibachiWebSocketClient extends AbstractWebSocketClient {
+
+    protected final String subscribeMessage;
+
+    public HibachiWebSocketClient(String serverUri,
+                                  IWebSocketProcessor processor,
+                                  String authApiKey,
+                                  String hibachiClient,
+                                  String subscribeMessage) throws Exception {
+        super(buildUri(serverUri, hibachiClient).toString(), null, processor);
+        this.subscribeMessage = subscribeMessage;
+        Map<String, String> headers = new HashMap<>();
+        if (authApiKey != null && !authApiKey.isBlank()) {
+            headers.put("Authorization", authApiKey);
+        }
+        if (hibachiClient != null && !hibachiClient.isBlank()) {
+            headers.put("Hibachi-Client", hibachiClient);
+        }
+        for (Map.Entry<String, String> e : headers.entrySet()) {
+            super.addHeader(e.getKey(), e.getValue());
+        }
+    }
+
+    public static HibachiWebSocketClient createMarket(String serverUri,
+                                                      IWebSocketProcessor processor,
+                                                      String hibachiClient,
+                                                      String subscribeMessage) throws Exception {
+        return new HibachiWebSocketClient(serverUri, processor, null, hibachiClient, subscribeMessage);
+    }
+
+    public static HibachiWebSocketClient createPrivate(String serverUri,
+                                                       String accountId,
+                                                       IWebSocketProcessor processor,
+                                                       String authApiKey,
+                                                       String hibachiClient) throws Exception {
+        String urlWithAccount = appendQueryParam(serverUri, "accountId", accountId);
+        return new HibachiWebSocketClient(urlWithAccount, processor, authApiKey, hibachiClient, null);
+    }
+
+    @Override
+    public void onOpen(ServerHandshake handshakedata) {
+        processor.connectionOpened();
+        if (subscribeMessage != null && !subscribeMessage.isBlank()) {
+            send(subscribeMessage);
+        }
+    }
+
+    @Override
+    public void onError(Exception ex) {
+        super.onError(ex);
+        if (processor != null) {
+            processor.connectionError(ex);
+        }
+    }
+
+    private static URI buildUri(String serverUri, String hibachiClient) {
+        String url = appendQueryParam(serverUri, "hibachiClient", hibachiClient);
+        try {
+            return new URI(url);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid Hibachi WebSocket URI: " + url, e);
+        }
+    }
+
+    static String appendQueryParam(String url, String name, String value) {
+        if (url == null || name == null || value == null || value.isBlank()) {
+            return url;
+        }
+        char sep = url.contains("?") ? '&' : '?';
+        return url + sep + name + "=" + value;
+    }
+
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/account/HibachiAccountSnapshot.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/account/HibachiAccountSnapshot.java
@@ -1,0 +1,26 @@
+package com.fueledbychai.hibachi.common.api.ws.account;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+
+public class HibachiAccountSnapshot {
+
+    private final long accountId;
+    private final BigDecimal balance;
+    private final List<HibachiPosition> positions;
+    private final String listenKey;
+
+    public HibachiAccountSnapshot(long accountId, BigDecimal balance, List<HibachiPosition> positions,
+                                  String listenKey) {
+        this.accountId = accountId;
+        this.balance = balance;
+        this.positions = positions == null ? Collections.emptyList() : List.copyOf(positions);
+        this.listenKey = listenKey;
+    }
+
+    public long getAccountId() { return accountId; }
+    public BigDecimal getBalance() { return balance; }
+    public List<HibachiPosition> getPositions() { return positions; }
+    public String getListenKey() { return listenKey; }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/account/HibachiAccountSnapshotListener.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/account/HibachiAccountSnapshotListener.java
@@ -1,0 +1,6 @@
+package com.fueledbychai.hibachi.common.api.ws.account;
+
+@FunctionalInterface
+public interface HibachiAccountSnapshotListener {
+    void onAccountSnapshot(HibachiAccountSnapshot snapshot);
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/account/HibachiAccountStreamMessages.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/account/HibachiAccountStreamMessages.java
@@ -1,0 +1,41 @@
+package com.fueledbychai.hibachi.common.api.ws.account;
+
+import java.time.Instant;
+
+import org.json.JSONObject;
+
+/**
+ * Builders for Hibachi account-stream WebSocket messages.
+ *
+ * <p>See {@code hibachi_xyz/api_ws_account.py} in the Python SDK.
+ */
+public final class HibachiAccountStreamMessages {
+
+    private HibachiAccountStreamMessages() {
+    }
+
+    /** Builds the {@code stream.start} request. */
+    public static String buildStreamStart(long id, long accountId) {
+        JSONObject p = new JSONObject();
+        p.put("accountId", accountId);
+        JSONObject root = new JSONObject();
+        root.put("id", id);
+        root.put("method", "stream.start");
+        root.put("params", p);
+        root.put("timestamp", Instant.now().getEpochSecond());
+        return root.toString();
+    }
+
+    /** Builds the {@code stream.ping} keepalive (recommended every ~14s). */
+    public static String buildStreamPing(long id, long accountId, String listenKey) {
+        JSONObject p = new JSONObject();
+        p.put("accountId", accountId);
+        p.put("listenKey", listenKey);
+        JSONObject root = new JSONObject();
+        root.put("id", id);
+        root.put("method", "stream.ping");
+        root.put("params", p);
+        root.put("timestamp", Instant.now().getEpochSecond());
+        return root.toString();
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/account/HibachiPosition.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/account/HibachiPosition.java
@@ -1,0 +1,42 @@
+package com.fueledbychai.hibachi.common.api.ws.account;
+
+import java.math.BigDecimal;
+
+public class HibachiPosition {
+
+    public enum Direction { LONG, SHORT }
+
+    private final String symbol;
+    private final Direction direction;
+    private final BigDecimal quantity;
+    private final BigDecimal openPrice;
+    private final BigDecimal markPrice;
+    private final BigDecimal entryNotional;
+    private final BigDecimal notionalValue;
+    private final BigDecimal unrealizedTradingPnl;
+    private final BigDecimal unrealizedFundingPnl;
+
+    public HibachiPosition(String symbol, Direction direction, BigDecimal quantity, BigDecimal openPrice,
+                           BigDecimal markPrice, BigDecimal entryNotional, BigDecimal notionalValue,
+                           BigDecimal unrealizedTradingPnl, BigDecimal unrealizedFundingPnl) {
+        this.symbol = symbol;
+        this.direction = direction;
+        this.quantity = quantity;
+        this.openPrice = openPrice;
+        this.markPrice = markPrice;
+        this.entryNotional = entryNotional;
+        this.notionalValue = notionalValue;
+        this.unrealizedTradingPnl = unrealizedTradingPnl;
+        this.unrealizedFundingPnl = unrealizedFundingPnl;
+    }
+
+    public String getSymbol() { return symbol; }
+    public Direction getDirection() { return direction; }
+    public BigDecimal getQuantity() { return quantity; }
+    public BigDecimal getOpenPrice() { return openPrice; }
+    public BigDecimal getMarkPrice() { return markPrice; }
+    public BigDecimal getEntryNotional() { return entryNotional; }
+    public BigDecimal getNotionalValue() { return notionalValue; }
+    public BigDecimal getUnrealizedTradingPnl() { return unrealizedTradingPnl; }
+    public BigDecimal getUnrealizedFundingPnl() { return unrealizedFundingPnl; }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/market/HibachiAskBidUpdate.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/market/HibachiAskBidUpdate.java
@@ -1,0 +1,30 @@
+package com.fueledbychai.hibachi.common.api.ws.market;
+
+import java.math.BigDecimal;
+
+public class HibachiAskBidUpdate {
+
+    private final String symbol;
+    private final BigDecimal bidPrice;
+    private final BigDecimal bidSize;
+    private final BigDecimal askPrice;
+    private final BigDecimal askSize;
+    private final long timestamp;
+
+    public HibachiAskBidUpdate(String symbol, BigDecimal bidPrice, BigDecimal bidSize,
+                               BigDecimal askPrice, BigDecimal askSize, long timestamp) {
+        this.symbol = symbol;
+        this.bidPrice = bidPrice;
+        this.bidSize = bidSize;
+        this.askPrice = askPrice;
+        this.askSize = askSize;
+        this.timestamp = timestamp;
+    }
+
+    public String getSymbol() { return symbol; }
+    public BigDecimal getBidPrice() { return bidPrice; }
+    public BigDecimal getBidSize() { return bidSize; }
+    public BigDecimal getAskPrice() { return askPrice; }
+    public BigDecimal getAskSize() { return askSize; }
+    public long getTimestamp() { return timestamp; }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/market/HibachiMarkPriceUpdate.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/market/HibachiMarkPriceUpdate.java
@@ -1,0 +1,20 @@
+package com.fueledbychai.hibachi.common.api.ws.market;
+
+import java.math.BigDecimal;
+
+public class HibachiMarkPriceUpdate {
+
+    private final String symbol;
+    private final BigDecimal markPrice;
+    private final long timestamp;
+
+    public HibachiMarkPriceUpdate(String symbol, BigDecimal markPrice, long timestamp) {
+        this.symbol = symbol;
+        this.markPrice = markPrice;
+        this.timestamp = timestamp;
+    }
+
+    public String getSymbol() { return symbol; }
+    public BigDecimal getMarkPrice() { return markPrice; }
+    public long getTimestamp() { return timestamp; }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/market/HibachiMarketListeners.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/market/HibachiMarketListeners.java
@@ -1,0 +1,30 @@
+package com.fueledbychai.hibachi.common.api.ws.market;
+
+/**
+ * Listener interfaces for Hibachi market WebSocket topics.
+ */
+public final class HibachiMarketListeners {
+
+    private HibachiMarketListeners() {
+    }
+
+    @FunctionalInterface
+    public interface MarkPriceListener {
+        void onMarkPrice(HibachiMarkPriceUpdate update);
+    }
+
+    @FunctionalInterface
+    public interface AskBidListener {
+        void onAskBid(HibachiAskBidUpdate update);
+    }
+
+    @FunctionalInterface
+    public interface OrderBookListener {
+        void onOrderBook(HibachiOrderBookUpdate update);
+    }
+
+    @FunctionalInterface
+    public interface TradeListener {
+        void onTrade(HibachiTradeUpdate update);
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/market/HibachiOrderBookUpdate.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/market/HibachiOrderBookUpdate.java
@@ -1,0 +1,39 @@
+package com.fueledbychai.hibachi.common.api.ws.market;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+
+public class HibachiOrderBookUpdate {
+
+    private final String symbol;
+    private final List<Level> bids;
+    private final List<Level> asks;
+    private final long timestamp;
+    private final boolean snapshot;
+
+    public HibachiOrderBookUpdate(String symbol, List<Level> bids, List<Level> asks,
+                                  long timestamp, boolean snapshot) {
+        this.symbol = symbol;
+        this.bids = bids == null ? Collections.emptyList() : List.copyOf(bids);
+        this.asks = asks == null ? Collections.emptyList() : List.copyOf(asks);
+        this.timestamp = timestamp;
+        this.snapshot = snapshot;
+    }
+
+    public String getSymbol() { return symbol; }
+    public List<Level> getBids() { return bids; }
+    public List<Level> getAsks() { return asks; }
+    public long getTimestamp() { return timestamp; }
+    public boolean isSnapshot() { return snapshot; }
+
+    public static class Level {
+        public final BigDecimal price;
+        public final BigDecimal size;
+
+        public Level(BigDecimal price, BigDecimal size) {
+            this.price = price;
+            this.size = size;
+        }
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/market/HibachiTradeUpdate.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/market/HibachiTradeUpdate.java
@@ -1,0 +1,32 @@
+package com.fueledbychai.hibachi.common.api.ws.market;
+
+import java.math.BigDecimal;
+
+import com.fueledbychai.hibachi.common.api.order.HibachiSide;
+
+public class HibachiTradeUpdate {
+
+    private final String symbol;
+    private final BigDecimal price;
+    private final BigDecimal quantity;
+    private final HibachiSide side;
+    private final long timestamp;
+    private final String tradeId;
+
+    public HibachiTradeUpdate(String symbol, BigDecimal price, BigDecimal quantity,
+                              HibachiSide side, long timestamp, String tradeId) {
+        this.symbol = symbol;
+        this.price = price;
+        this.quantity = quantity;
+        this.side = side;
+        this.timestamp = timestamp;
+        this.tradeId = tradeId;
+    }
+
+    public String getSymbol() { return symbol; }
+    public BigDecimal getPrice() { return price; }
+    public BigDecimal getQuantity() { return quantity; }
+    public HibachiSide getSide() { return side; }
+    public long getTimestamp() { return timestamp; }
+    public String getTradeId() { return tradeId; }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/trade/HibachiOrderStatus.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/trade/HibachiOrderStatus.java
@@ -1,0 +1,14 @@
+package com.fueledbychai.hibachi.common.api.ws.trade;
+
+/**
+ * Hibachi order lifecycle status, normalized for the framework's broker layer.
+ */
+public enum HibachiOrderStatus {
+    NEW,
+    PARTIALLY_FILLED,
+    FILLED,
+    CANCELED,
+    REJECTED,
+    EXPIRED,
+    UNKNOWN
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/trade/HibachiOrderStatusListener.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/trade/HibachiOrderStatusListener.java
@@ -1,0 +1,6 @@
+package com.fueledbychai.hibachi.common.api.ws.trade;
+
+@FunctionalInterface
+public interface HibachiOrderStatusListener {
+    void onOrderStatus(HibachiOrderStatusUpdate update);
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/trade/HibachiOrderStatusUpdate.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/trade/HibachiOrderStatusUpdate.java
@@ -1,0 +1,49 @@
+package com.fueledbychai.hibachi.common.api.ws.trade;
+
+import java.math.BigDecimal;
+
+import com.fueledbychai.hibachi.common.api.order.HibachiSide;
+
+public class HibachiOrderStatusUpdate {
+
+    private final String orderId;
+    private final String clientOrderId;
+    private final String symbol;
+    private final HibachiSide side;
+    private final BigDecimal price;
+    private final BigDecimal quantity;
+    private final BigDecimal filledQuantity;
+    private final BigDecimal averageFillPrice;
+    private final HibachiOrderStatus status;
+    private final String reason;
+    private final long timestamp;
+
+    public HibachiOrderStatusUpdate(String orderId, String clientOrderId, String symbol, HibachiSide side,
+                                    BigDecimal price, BigDecimal quantity, BigDecimal filledQuantity,
+                                    BigDecimal averageFillPrice, HibachiOrderStatus status, String reason,
+                                    long timestamp) {
+        this.orderId = orderId;
+        this.clientOrderId = clientOrderId;
+        this.symbol = symbol;
+        this.side = side;
+        this.price = price;
+        this.quantity = quantity;
+        this.filledQuantity = filledQuantity;
+        this.averageFillPrice = averageFillPrice;
+        this.status = status;
+        this.reason = reason;
+        this.timestamp = timestamp;
+    }
+
+    public String getOrderId() { return orderId; }
+    public String getClientOrderId() { return clientOrderId; }
+    public String getSymbol() { return symbol; }
+    public HibachiSide getSide() { return side; }
+    public BigDecimal getPrice() { return price; }
+    public BigDecimal getQuantity() { return quantity; }
+    public BigDecimal getFilledQuantity() { return filledQuantity; }
+    public BigDecimal getAverageFillPrice() { return averageFillPrice; }
+    public HibachiOrderStatus getStatus() { return status; }
+    public String getReason() { return reason; }
+    public long getTimestamp() { return timestamp; }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/trade/HibachiTradeEnvelope.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/trade/HibachiTradeEnvelope.java
@@ -1,0 +1,121 @@
+package com.fueledbychai.hibachi.common.api.ws.trade;
+
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.json.JSONObject;
+
+/**
+ * Builds the JSON envelope sent over the Hibachi trade WebSocket.
+ *
+ * <p>Base shape: {@code {"id": <int>, "method": "<name>", "params": {...}, "signature": "<hex>"}}.
+ *
+ * <p>Quirks mirrored from {@code hibachi_xyz/api_ws_trade.py}:
+ * <ul>
+ *   <li>{@link HibachiTradeMethod#ORDER_PLACE}: signature appears BOTH inside {@code params}
+ *       and at top level (api_ws_trade.py:198-203).</li>
+ *   <li>{@link HibachiTradeMethod#ORDER_MODIFY}: signature is pulled OUT of {@code params}
+ *       and only placed at the top level (api_ws_trade.py:324-325).</li>
+ *   <li>{@link HibachiTradeMethod#ORDER_CANCEL} / {@link HibachiTradeMethod#ORDERS_CANCEL}:
+ *       signature top-level only.</li>
+ *   <li>{@link HibachiTradeMethod#ORDERS_BATCH}: no top-level signature — each child carries
+ *       its own.</li>
+ *   <li>{@link HibachiTradeMethod#ORDER_STATUS} / {@link HibachiTradeMethod#ORDERS_STATUS} /
+ *       {@link HibachiTradeMethod#ORDERS_ENABLE_CANCEL_ON_DISCONNECT}: no signature.</li>
+ * </ul>
+ */
+public final class HibachiTradeEnvelope {
+
+    private static final AtomicLong CORRELATION_ID = new AtomicLong(ThreadLocalRandom.current().nextLong(1, 1_000_000));
+
+    private HibachiTradeEnvelope() {
+    }
+
+    /** Allocates a fresh monotonic correlation id. */
+    public static long nextCorrelationId() {
+        return CORRELATION_ID.incrementAndGet();
+    }
+
+    /** Builds an {@link HibachiTradeMethod#ORDER_PLACE} envelope. */
+    public static String buildPlace(long id, Map<String, Object> params, String signature) {
+        JSONObject p = new JSONObject(params);
+        p.put("signature", signature);
+        JSONObject root = new JSONObject();
+        root.put("id", id);
+        root.put("method", HibachiTradeMethod.ORDER_PLACE);
+        root.put("params", p);
+        root.put("signature", signature);
+        return root.toString();
+    }
+
+    /** Builds an {@link HibachiTradeMethod#ORDER_MODIFY} envelope. */
+    public static String buildModify(long id, Map<String, Object> params, String signature) {
+        JSONObject p = new JSONObject(params);
+        // SDK pops signature out of params; mirror exactly.
+        p.remove("signature");
+        JSONObject root = new JSONObject();
+        root.put("id", id);
+        root.put("method", HibachiTradeMethod.ORDER_MODIFY);
+        root.put("params", p);
+        root.put("signature", signature);
+        return root.toString();
+    }
+
+    /** Builds an {@link HibachiTradeMethod#ORDER_CANCEL} envelope. */
+    public static String buildCancel(long id, Map<String, Object> params, String signature) {
+        JSONObject root = new JSONObject();
+        root.put("id", id);
+        root.put("method", HibachiTradeMethod.ORDER_CANCEL);
+        root.put("params", new JSONObject(params));
+        root.put("signature", signature);
+        return root.toString();
+    }
+
+    /** Builds an {@link HibachiTradeMethod#ORDERS_CANCEL} envelope. */
+    public static String buildCancelAll(long id, long accountId, long nonce, String signature) {
+        JSONObject p = new JSONObject();
+        p.put("accountId", accountId);
+        p.put("nonce", nonce);
+        JSONObject root = new JSONObject();
+        root.put("id", id);
+        root.put("method", HibachiTradeMethod.ORDERS_CANCEL);
+        root.put("params", p);
+        root.put("signature", signature);
+        return root.toString();
+    }
+
+    /** Builds an {@link HibachiTradeMethod#ORDER_STATUS} envelope (no signature). */
+    public static String buildOrderStatus(long id, long accountId, String orderId) {
+        JSONObject p = new JSONObject();
+        p.put("orderId", orderId);
+        p.put("accountId", accountId);
+        JSONObject root = new JSONObject();
+        root.put("id", id);
+        root.put("method", HibachiTradeMethod.ORDER_STATUS);
+        root.put("params", p);
+        return root.toString();
+    }
+
+    /** Builds an {@link HibachiTradeMethod#ORDERS_STATUS} envelope (no signature). */
+    public static String buildOrdersStatus(long id, long accountId) {
+        JSONObject p = new JSONObject();
+        p.put("accountId", accountId);
+        JSONObject root = new JSONObject();
+        root.put("id", id);
+        root.put("method", HibachiTradeMethod.ORDERS_STATUS);
+        root.put("params", p);
+        return root.toString();
+    }
+
+    /** Builds an {@link HibachiTradeMethod#ORDERS_ENABLE_CANCEL_ON_DISCONNECT} envelope. */
+    public static String buildEnableCancelOnDisconnect(long id, long nonce) {
+        JSONObject p = new JSONObject();
+        p.put("nonce", nonce);
+        JSONObject root = new JSONObject();
+        root.put("id", id);
+        root.put("method", HibachiTradeMethod.ORDERS_ENABLE_CANCEL_ON_DISCONNECT);
+        root.put("params", p);
+        return root.toString();
+    }
+}

--- a/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/trade/HibachiTradeMethod.java
+++ b/commons/hibachi-common-api/src/main/java/com/fueledbychai/hibachi/common/api/ws/trade/HibachiTradeMethod.java
@@ -1,0 +1,21 @@
+package com.fueledbychai.hibachi.common.api.ws.trade;
+
+/**
+ * JSON-RPC method names supported by the Hibachi trade WebSocket.
+ *
+ * <p>See {@code hibachi_xyz/api_ws_trade.py} in the Python SDK.
+ */
+public final class HibachiTradeMethod {
+
+    public static final String ORDER_PLACE = "order.place";
+    public static final String ORDER_MODIFY = "order.modify";
+    public static final String ORDER_CANCEL = "order.cancel";
+    public static final String ORDERS_CANCEL = "orders.cancel";
+    public static final String ORDERS_BATCH = "orders.batch";
+    public static final String ORDER_STATUS = "order.status";
+    public static final String ORDERS_STATUS = "orders.status";
+    public static final String ORDERS_ENABLE_CANCEL_ON_DISCONNECT = "orders.enableCancelOnDisconnect";
+
+    private HibachiTradeMethod() {
+    }
+}

--- a/commons/hibachi-common-api/src/main/resources/META-INF/services/com.fueledbychai.util.ExchangeCapabilitiesProvider
+++ b/commons/hibachi-common-api/src/main/resources/META-INF/services/com.fueledbychai.util.ExchangeCapabilitiesProvider
@@ -1,0 +1,1 @@
+com.fueledbychai.hibachi.common.HibachiExchangeCapabilitiesProvider

--- a/commons/hibachi-common-api/src/main/resources/META-INF/services/com.fueledbychai.util.ExchangeRestApiProvider
+++ b/commons/hibachi-common-api/src/main/resources/META-INF/services/com.fueledbychai.util.ExchangeRestApiProvider
@@ -1,0 +1,1 @@
+com.fueledbychai.hibachi.common.api.HibachiRestApiProvider

--- a/commons/hibachi-common-api/src/main/resources/META-INF/services/com.fueledbychai.util.TickerRegistryProvider
+++ b/commons/hibachi-common-api/src/main/resources/META-INF/services/com.fueledbychai.util.TickerRegistryProvider
@@ -1,0 +1,1 @@
+com.fueledbychai.hibachi.common.HibachiTickerRegistryProvider

--- a/commons/hibachi-common-api/src/test/java/com/fueledbychai/hibachi/common/api/signer/HibachiPayloadPackerTest.java
+++ b/commons/hibachi-common-api/src/test/java/com/fueledbychai/hibachi/common/api/signer/HibachiPayloadPackerTest.java
@@ -1,0 +1,126 @@
+package com.fueledbychai.hibachi.common.api.signer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+import java.util.HexFormat;
+
+import org.junit.jupiter.api.Test;
+
+import com.fueledbychai.hibachi.common.api.HibachiContract;
+import com.fueledbychai.hibachi.common.api.order.HibachiSide;
+
+/**
+ * Bit-for-bit regression tests for {@link HibachiPayloadPacker} against the Python SDK
+ * at {@code /tmp/hibachi_sdk/python/hibachi_xyz/api.py}.
+ */
+class HibachiPayloadPackerTest {
+
+    private static final HibachiContract ETH_USDT_P = HibachiContract.builder()
+            .id(1)
+            .symbol("ETH/USDT-P")
+            .underlyingDecimals(9)
+            .settlementDecimals(6)
+            .build();
+
+    @Test
+    void packPlaceOrder_limitBid_matchesHandComputedPayload() {
+        // Inputs: contract.id=1, underlyingDecimals=9, settlementDecimals=6,
+        // nonce=1, qty=0.01, price=2500.0, side=BID, maxFeesPercent=0.5
+        byte[] bytes = HibachiPayloadPacker.packPlaceOrder(
+                1L,
+                ETH_USDT_P,
+                new BigDecimal("0.01"),
+                HibachiSide.BID,
+                new BigDecimal("2500.0"),
+                new BigDecimal("0.5"));
+
+        // Expected 40-byte payload:
+        //   nonce:    0000000000000001
+        //   contract: 00000001
+        //   quantity: 0000000000989680   (0.01 * 10^9 = 10_000_000 = 0x989680)
+        //   side:     00000001           (BID=1)
+        //   price:    0000000280000000   (2500 * 2^32 * 10^-3 = 10_737_418_240 = 0x280000000)
+        //   maxFees:  0000000002faf080   (0.5 * 10^8 = 50_000_000 = 0x2faf080)
+        String expected = "000000000000000100000001000000000098968000000001000000028000000000000000" +
+                "02faf080";
+        assertEquals(expected, HexFormat.of().formatHex(bytes));
+        assertEquals(40, bytes.length);
+    }
+
+    @Test
+    void packPlaceOrder_marketAsk_omitsPriceBytes_32ByteLength() {
+        byte[] bytes = HibachiPayloadPacker.packPlaceOrder(
+                1L,
+                ETH_USDT_P,
+                new BigDecimal("0.01"),
+                HibachiSide.ASK,
+                null,
+                new BigDecimal("0.5"));
+        // Market orders OMIT price bytes entirely — NOT zero-padded.
+        assertEquals(32, bytes.length);
+        String expected = "00000000000000010000000100000000009896800000000000000000" +
+                "02faf080";
+        assertEquals(expected, HexFormat.of().formatHex(bytes));
+    }
+
+    @Test
+    void packCancelOrder_orderId_yields8BytesBE() {
+        byte[] bytes = HibachiPayloadPacker.packCancelOrder(12345L, null);
+        assertEquals(8, bytes.length);
+        assertEquals("0000000000003039", HexFormat.of().formatHex(bytes));
+    }
+
+    @Test
+    void packCancelOrder_nonceFallback_yields8BytesBE() {
+        byte[] bytes = HibachiPayloadPacker.packCancelOrder(null, 1234567890L);
+        assertEquals(8, bytes.length);
+        assertEquals("00000000499602d2", HexFormat.of().formatHex(bytes));
+    }
+
+    @Test
+    void packCancelOrder_orderIdWinsOverNonce() {
+        byte[] bytes = HibachiPayloadPacker.packCancelOrder(1L, 2L);
+        assertEquals("0000000000000001", HexFormat.of().formatHex(bytes));
+    }
+
+    @Test
+    void packCancelOrder_bothNull_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> HibachiPayloadPacker.packCancelOrder(null, null));
+    }
+
+    @Test
+    void scaleQuantity_truncatesTowardZero() {
+        HibachiContract c = HibachiContract.builder().id(1).underlyingDecimals(9).settlementDecimals(6).build();
+        assertEquals(10_000_000L, HibachiPayloadPacker.scaleQuantity(new BigDecimal("0.01"), c));
+        // 0.0123456789 * 1e9 = 12_345_678.9 → truncate → 12_345_678
+        assertEquals(12_345_678L, HibachiPayloadPacker.scaleQuantity(new BigDecimal("0.0123456789"), c));
+    }
+
+    @Test
+    void scalePrice_appliesFixedPointAndDecimalDelta() {
+        HibachiContract c = HibachiContract.builder().id(1).underlyingDecimals(9).settlementDecimals(6).build();
+        // 2500 * 2^32 * 10^-3 = 10_737_418_240
+        assertEquals(10_737_418_240L, HibachiPayloadPacker.scalePrice(new BigDecimal("2500.0"), c));
+    }
+
+    @Test
+    void scaleMaxFeesPercent_hardCoded1e8() {
+        assertEquals(50_000_000L, HibachiPayloadPacker.scaleMaxFeesPercent(new BigDecimal("0.5")));
+        assertEquals(100_000_000L, HibachiPayloadPacker.scaleMaxFeesPercent(new BigDecimal("1")));
+        assertEquals(25_000_000L, HibachiPayloadPacker.scaleMaxFeesPercent(new BigDecimal("0.25")));
+    }
+
+    @Test
+    void packPlaceOrder_modifyOrderHasIdenticalLayout() {
+        // Modify reuses the same packer (api.py:2114-2171 → __create_or_update_order_payload).
+        byte[] place = HibachiPayloadPacker.packPlaceOrder(1L, ETH_USDT_P,
+                new BigDecimal("0.02"), HibachiSide.BID, new BigDecimal("2600.0"), new BigDecimal("0.5"));
+        // A modify with the same inputs produces the same bytes — identity check.
+        byte[] modify = HibachiPayloadPacker.packPlaceOrder(1L, ETH_USDT_P,
+                new BigDecimal("0.02"), HibachiSide.BID, new BigDecimal("2600.0"), new BigDecimal("0.5"));
+        assertEquals(HexFormat.of().formatHex(place), HexFormat.of().formatHex(modify));
+    }
+}

--- a/commons/hibachi-common-api/src/test/java/com/fueledbychai/hibachi/common/api/signer/HmacHibachiSignerTest.java
+++ b/commons/hibachi-common-api/src/test/java/com/fueledbychai/hibachi/common/api/signer/HmacHibachiSignerTest.java
@@ -1,0 +1,58 @@
+package com.fueledbychai.hibachi.common.api.signer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validates HMAC-SHA256 wiring against RFC 4231 / canonical test vectors, and pins the
+ * lowercase-hex output contract.
+ *
+ * <p>The Python SDK reference ({@code hibachi_xyz/api.py:__sign_payload}) uses
+ * {@code hmac.new(secret.encode(), payload, sha256).hexdigest()} — raw UTF-8 secret,
+ * raw payload bytes, lowercase hex.
+ */
+class HmacHibachiSignerTest {
+
+    @Test
+    void sign_asciiPayload_matchesKnownHmacSha256() {
+        // Input: secret="key", message="The quick brown fox jumps over the lazy dog"
+        // Canonical HMAC-SHA256 output (RFC 4231-style hand-verified):
+        //   f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8
+        HmacHibachiSigner signer = new HmacHibachiSigner("key");
+        String sig = signer.sign("The quick brown fox jumps over the lazy dog".getBytes(StandardCharsets.UTF_8));
+        assertEquals("f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8", sig);
+    }
+
+    @Test
+    void sign_emptyMessage_spaceKey_matchesOpensslReference() {
+        // printf '' | openssl dgst -sha256 -hmac ' '
+        HmacHibachiSigner signer = new HmacHibachiSigner(" ");
+        String sig = signer.sign(new byte[0]);
+        assertEquals("7ff2d145855d701733499c9212d4fa10d70e0dfd4c24c3ba68f2e7c031253e44", sig);
+    }
+
+    @Test
+    void sign_utf8SecretEncoding_notHexDecoded() {
+        // Critical: the secret "deadbeef" must be treated as ASCII bytes (UTF-8), NOT hex-decoded.
+        // Python SDK uses secret.encode(). Reference:
+        //   printf 'test' | openssl dgst -sha256 -hmac 'deadbeef'
+        HmacHibachiSigner signer = new HmacHibachiSigner("deadbeef");
+        String sig = signer.sign("test".getBytes(StandardCharsets.UTF_8));
+        assertEquals("635a17f871abfe7363b7bb590bc8f74abd3693c56b2c2656f1d841c558355b02", sig);
+    }
+
+    @Test
+    void constructor_rejectsNullOrEmptySecret() {
+        assertThrows(IllegalArgumentException.class, () -> new HmacHibachiSigner(null));
+        assertThrows(IllegalArgumentException.class, () -> new HmacHibachiSigner(""));
+    }
+
+    @Test
+    void scheme_isHmacSha256() {
+        assertEquals(SignatureScheme.HMAC_SHA256, new HmacHibachiSigner("x").scheme());
+    }
+}

--- a/commons/hibachi-common-api/src/test/java/com/fueledbychai/hibachi/common/api/ws/HibachiMarketSubscribeMessageTest.java
+++ b/commons/hibachi-common-api/src/test/java/com/fueledbychai/hibachi/common/api/ws/HibachiMarketSubscribeMessageTest.java
@@ -1,0 +1,66 @@
+package com.fueledbychai.hibachi.common.api.ws;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class HibachiMarketSubscribeMessageTest {
+
+    @Test
+    void subscribe_singleTopic_buildsExpectedJson() {
+        // Reference fixture from Python SDK: tests/unit/ws/test_market_ws.py
+        String json = HibachiMarketSubscribeMessage.subscribe("BTC/USDT-P", "mark_price");
+        JSONObject root = new JSONObject(json);
+        assertEquals("subscribe", root.getString("method"));
+        JSONObject parameters = root.getJSONObject("parameters");
+        assertEquals(1, parameters.getJSONArray("subscriptions").length());
+        JSONObject sub = parameters.getJSONArray("subscriptions").getJSONObject(0);
+        assertEquals("BTC/USDT-P", sub.getString("symbol"));
+        assertEquals("mark_price", sub.getString("topic"));
+    }
+
+    @Test
+    void subscribe_outerKeyIsParametersNotParams() {
+        // Critical — market WS uses "parameters" while trade/account WS use "params".
+        // See api_ws_market.py:110-116.
+        String json = HibachiMarketSubscribeMessage.subscribe("ETH/USDT-P", "orderbook");
+        JSONObject root = new JSONObject(json);
+        org.junit.jupiter.api.Assertions.assertTrue(root.has("parameters"));
+        org.junit.jupiter.api.Assertions.assertFalse(root.has("params"));
+    }
+
+    @Test
+    void subscribe_multipleSubscriptions_preservesOrder() {
+        String json = HibachiMarketSubscribeMessage.subscribe(List.of(
+                new HibachiMarketSubscribeMessage.Subscription("BTC/USDT-P", "ask_bid_price"),
+                new HibachiMarketSubscribeMessage.Subscription("BTC/USDT-P", "mark_price")));
+        JSONObject root = new JSONObject(json);
+        JSONObject sub0 = root.getJSONObject("parameters").getJSONArray("subscriptions").getJSONObject(0);
+        JSONObject sub1 = root.getJSONObject("parameters").getJSONArray("subscriptions").getJSONObject(1);
+        assertEquals("ask_bid_price", sub0.getString("topic"));
+        assertEquals("mark_price", sub1.getString("topic"));
+    }
+
+    @Test
+    void unsubscribe_usesUnsubscribeMethod() {
+        String json = HibachiMarketSubscribeMessage.unsubscribe("BTC/USDT-P", "trades");
+        assertEquals("unsubscribe", new JSONObject(json).getString("method"));
+    }
+
+    @Test
+    void emptySubscriptionList_throws() {
+        assertThrows(IllegalArgumentException.class, () -> HibachiMarketSubscribeMessage.subscribe(List.of()));
+    }
+
+    @Test
+    void blankSymbolOrTopic_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new HibachiMarketSubscribeMessage.Subscription("", "mark_price"));
+        assertThrows(IllegalArgumentException.class,
+                () -> new HibachiMarketSubscribeMessage.Subscription("BTC/USDT-P", ""));
+    }
+}

--- a/commons/hibachi-common-api/src/test/java/com/fueledbychai/hibachi/common/api/ws/trade/HibachiTradeEnvelopeTest.java
+++ b/commons/hibachi-common-api/src/test/java/com/fueledbychai/hibachi/common/api/ws/trade/HibachiTradeEnvelopeTest.java
@@ -1,0 +1,76 @@
+package com.fueledbychai.hibachi.common.api.ws.trade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+class HibachiTradeEnvelopeTest {
+
+    @Test
+    void buildPlace_putsSignatureBothInsideParamsAndAtTopLevel() {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("symbol", "BTC/USDT-P");
+        params.put("accountId", 12345);
+        String env = HibachiTradeEnvelope.buildPlace(99L, params, "abcdef");
+        JSONObject root = new JSONObject(env);
+        assertEquals(99L, root.getLong("id"));
+        assertEquals("order.place", root.getString("method"));
+        assertEquals("abcdef", root.getString("signature"));
+        assertEquals("abcdef", root.getJSONObject("params").getString("signature"));
+    }
+
+    @Test
+    void buildModify_putsSignatureOnlyAtTopLevel() {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("orderId", "9999");
+        params.put("accountId", 12345);
+        params.put("signature", "leakedFromCaller"); // ensure we strip it
+        String env = HibachiTradeEnvelope.buildModify(1L, params, "realsig");
+        JSONObject root = new JSONObject(env);
+        assertEquals("realsig", root.getString("signature"));
+        assertFalse(root.getJSONObject("params").has("signature"));
+    }
+
+    @Test
+    void buildCancel_envelopeHasTopLevelSignature() {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("orderId", "9999");
+        params.put("accountId", 12345);
+        String env = HibachiTradeEnvelope.buildCancel(2L, params, "sig");
+        JSONObject root = new JSONObject(env);
+        assertEquals("order.cancel", root.getString("method"));
+        assertEquals("sig", root.getString("signature"));
+        assertEquals("9999", root.getJSONObject("params").getString("orderId"));
+    }
+
+    @Test
+    void buildOrderStatus_hasNoSignature() {
+        String env = HibachiTradeEnvelope.buildOrderStatus(7L, 12345, "abc");
+        JSONObject root = new JSONObject(env);
+        assertEquals("order.status", root.getString("method"));
+        assertFalse(root.has("signature"));
+        assertEquals("abc", root.getJSONObject("params").getString("orderId"));
+    }
+
+    @Test
+    void buildCancelAll_paramsCarryAccountIdAndNonce() {
+        String env = HibachiTradeEnvelope.buildCancelAll(11L, 12345, 1700000000000L, "sig");
+        JSONObject root = new JSONObject(env);
+        assertEquals("orders.cancel", root.getString("method"));
+        assertEquals(12345, root.getJSONObject("params").getInt("accountId"));
+        assertEquals(1700000000000L, root.getJSONObject("params").getLong("nonce"));
+    }
+
+    @Test
+    void nextCorrelationId_isMonotonic() {
+        long a = HibachiTradeEnvelope.nextCorrelationId();
+        long b = HibachiTradeEnvelope.nextCorrelationId();
+        assertTrue(b > a);
+    }
+}

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -53,6 +53,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <module>bybit-common-api</module>
     <module>drift-common-api</module>
     <module>aster-common-api</module>
+    <module>hibachi-common-api</module>
   </modules>
   
 </project>

--- a/docs/generated/README.md
+++ b/docs/generated/README.md
@@ -49,4 +49,4 @@ java -cp "target/classes:target/dependency/*" \
 ```
 
 ---
-*Generated on: 2026-04-07T13:35:06.244409*
+*Generated on: 2026-04-17T10:23:38.039965*

--- a/examples/CryptoExamples/docs/generated/README.md
+++ b/examples/CryptoExamples/docs/generated/README.md
@@ -49,4 +49,4 @@ java -cp "target/classes:target/dependency/*" \
 ```
 
 ---
-*Generated on: 2026-03-18T09:13:07.710541*
+*Generated on: 2026-04-15T16:05:02.964206*

--- a/examples/CryptoExamples/pom.xml
+++ b/examples/CryptoExamples/pom.xml
@@ -87,6 +87,16 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>hibachi-market-data-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibachi-broker-api-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>binance-futures-market-data-impl</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/examples/CryptoExamples/src/main/java/com/fueledbychai/paradex/example/market/data/HibachiMarketDataExample.java
+++ b/examples/CryptoExamples/src/main/java/com/fueledbychai/paradex/example/market/data/HibachiMarketDataExample.java
@@ -15,6 +15,7 @@ import com.fueledbychai.marketdata.QuoteEngine;
 import com.fueledbychai.marketdata.QuoteType;
 import com.fueledbychai.util.ITickerRegistry;
 import com.fueledbychai.util.TickerRegistryFactory;
+import com.fueledbychai.websocket.ProxyConfig;
 
 /**
  * Subscribes to Hibachi L1, L2, and order-flow streams for a single perp.
@@ -33,6 +34,9 @@ public class HibachiMarketDataExample {
     protected static final Duration RUN_DURATION = Duration.ofMinutes(1);
 
     public void start(String symbol, InstrumentType instrumentType) throws InterruptedException {
+        ProxyConfig.getInstance().setRunningLocally(true);
+        logger.info("Proxy config: {}", ProxyConfig.getInstance().getProxy());
+
         ITickerRegistry registry = TickerRegistryFactory.getInstance(Exchange.HIBACHI);
         Ticker ticker = registry.lookupByBrokerSymbol(instrumentType, symbol);
         if (ticker == null) {
@@ -59,13 +63,18 @@ public class HibachiMarketDataExample {
     }
 
     protected void onLevel1(ILevel1Quote quote) {
-        logger.info("L1 {} bid={} bidSize={} ask={} askSize={} mark={}",
+        logger.info("L1 {} bid={} bidSize={} ask={} askSize={} mark={} last={} lastSize={} vol={} volNotional={} funding={}",
                 quote.getTicker().getSymbol(),
                 value(quote, QuoteType.BID),
                 value(quote, QuoteType.BID_SIZE),
                 value(quote, QuoteType.ASK),
                 value(quote, QuoteType.ASK_SIZE),
-                value(quote, QuoteType.MARK_PRICE));
+                value(quote, QuoteType.MARK_PRICE),
+                value(quote, QuoteType.LAST),
+                value(quote, QuoteType.LAST_SIZE),
+                value(quote, QuoteType.VOLUME),
+                value(quote, QuoteType.VOLUME_NOTIONAL),
+                value(quote, QuoteType.FUNDING_RATE_APR));
     }
 
     protected void onLevel2(ILevel2Quote quote) {

--- a/examples/CryptoExamples/src/main/java/com/fueledbychai/paradex/example/market/data/HibachiMarketDataExample.java
+++ b/examples/CryptoExamples/src/main/java/com/fueledbychai/paradex/example/market/data/HibachiMarketDataExample.java
@@ -1,0 +1,101 @@
+package com.fueledbychai.paradex.example.market.data;
+
+import java.time.Duration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fueledbychai.data.Exchange;
+import com.fueledbychai.data.InstrumentType;
+import com.fueledbychai.data.Ticker;
+import com.fueledbychai.marketdata.ILevel1Quote;
+import com.fueledbychai.marketdata.ILevel2Quote;
+import com.fueledbychai.marketdata.OrderFlow;
+import com.fueledbychai.marketdata.QuoteEngine;
+import com.fueledbychai.marketdata.QuoteType;
+import com.fueledbychai.util.ITickerRegistry;
+import com.fueledbychai.util.TickerRegistryFactory;
+
+/**
+ * Subscribes to Hibachi L1, L2, and order-flow streams for a single perp.
+ *
+ * <p>L1 is composed from two Hibachi topics — {@code ask_bid_price} (BBO) and
+ * {@code mark_price}. L2 is the {@code orderbook} topic and OrderFlow is {@code trades}.
+ *
+ * <p>Hibachi symbols are canonical, e.g. {@code BTC/USDT-P}. The default below is
+ * {@code BTC} which the Hibachi ticker registry expands to {@code BTC/USDT-P}.
+ */
+public class HibachiMarketDataExample {
+
+    protected static final Logger logger = LoggerFactory.getLogger(HibachiMarketDataExample.class);
+    protected static final String DEFAULT_SYMBOL = "BTC";
+    protected static final InstrumentType DEFAULT_TYPE = InstrumentType.PERPETUAL_FUTURES;
+    protected static final Duration RUN_DURATION = Duration.ofMinutes(1);
+
+    public void start(String symbol, InstrumentType instrumentType) throws InterruptedException {
+        ITickerRegistry registry = TickerRegistryFactory.getInstance(Exchange.HIBACHI);
+        Ticker ticker = registry.lookupByBrokerSymbol(instrumentType, symbol);
+        if (ticker == null) {
+            ticker = registry.lookupByCommonSymbol(instrumentType, symbol);
+        }
+        if (ticker == null) {
+            throw new IllegalArgumentException("Unknown Hibachi ticker for " + instrumentType + ": " + symbol);
+        }
+
+        QuoteEngine quoteEngine = QuoteEngine.getInstance(Exchange.HIBACHI);
+        quoteEngine.startEngine();
+
+        quoteEngine.subscribeLevel1(ticker, this::onLevel1);
+        quoteEngine.subscribeMarketDepth(ticker, this::onLevel2);
+        quoteEngine.subscribeOrderFlow(ticker, this::onOrderFlow);
+
+        logger.info("Subscribed to Hibachi market data for {} ({})", ticker.getSymbol(), ticker.getInstrumentType());
+
+        try {
+            Thread.sleep(RUN_DURATION.toMillis());
+        } finally {
+            quoteEngine.stopEngine();
+        }
+    }
+
+    protected void onLevel1(ILevel1Quote quote) {
+        logger.info("L1 {} bid={} bidSize={} ask={} askSize={} mark={}",
+                quote.getTicker().getSymbol(),
+                value(quote, QuoteType.BID),
+                value(quote, QuoteType.BID_SIZE),
+                value(quote, QuoteType.ASK),
+                value(quote, QuoteType.ASK_SIZE),
+                value(quote, QuoteType.MARK_PRICE));
+    }
+
+    protected void onLevel2(ILevel2Quote quote) {
+        logger.info("L2 {} bestBid={}x{} bestAsk={}x{}",
+                quote.getTicker().getSymbol(),
+                quote.getOrderBook().getBestBid().getPrice(),
+                quote.getOrderBook().getBestBid().getSize(),
+                quote.getOrderBook().getBestAsk().getPrice(),
+                quote.getOrderBook().getBestAsk().getSize());
+    }
+
+    protected void onOrderFlow(OrderFlow orderFlow) {
+        logger.info("Trade {} side={} price={} size={}",
+                orderFlow.getTicker().getSymbol(), orderFlow.getSide(),
+                orderFlow.getPrice(), orderFlow.getSize());
+    }
+
+    protected String value(ILevel1Quote quote, QuoteType type) {
+        if (quote == null || type == null || !quote.containsType(type)) {
+            return "null";
+        }
+        return String.valueOf(quote.getValue(type));
+    }
+
+    public static void main(String[] args) throws Exception {
+        String symbol = args.length > 0 ? args[0] : DEFAULT_SYMBOL;
+        InstrumentType instrumentType = args.length > 1
+                ? InstrumentType.valueOf(args[1].trim().toUpperCase())
+                : DEFAULT_TYPE;
+
+        new HibachiMarketDataExample().start(symbol, instrumentType);
+    }
+}

--- a/implementations/broker-api/hibachi-broker-api-impl/pom.xml
+++ b/implementations/broker-api/hibachi-broker-api-impl/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.fueledbychai</groupId>
+        <artifactId>broker-api</artifactId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>com.fueledbychai</groupId>
+    <artifactId>hibachi-broker-api-impl</artifactId>
+    <version>0.2.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>hibachi-broker-api-impl</name>
+    <description>Hibachi exchange broker integration</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fueledbychai</groupId>
+            <artifactId>fueledbychai-broker-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fueledbychai</groupId>
+            <artifactId>fueledbychai-commons-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fueledbychai</groupId>
+            <artifactId>hibachi-common-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M9</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/implementations/broker-api/hibachi-broker-api-impl/src/main/java/com/fueledbychai/broker/hibachi/HibachiAccountStreamClient.java
+++ b/implementations/broker-api/hibachi-broker-api-impl/src/main/java/com/fueledbychai/broker/hibachi/HibachiAccountStreamClient.java
@@ -1,0 +1,137 @@
+package com.fueledbychai.broker.hibachi;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fueledbychai.hibachi.common.api.HibachiConfiguration;
+import com.fueledbychai.hibachi.common.api.ws.HibachiJsonProcessor;
+import com.fueledbychai.hibachi.common.api.ws.HibachiWebSocketClient;
+import com.fueledbychai.hibachi.common.api.ws.account.HibachiAccountStreamMessages;
+import com.fueledbychai.hibachi.common.api.ws.trade.HibachiTradeEnvelope;
+
+/**
+ * Account WebSocket client for Hibachi.
+ *
+ * <p>On connect: sends {@code stream.start}, captures the {@code listenKey} from the
+ * response, then schedules {@code stream.ping} every
+ * {@link HibachiConfiguration#getAccountWsPingSeconds()} (default 14s).
+ */
+public class HibachiAccountStreamClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(HibachiAccountStreamClient.class);
+
+    protected final HibachiConfiguration config;
+    protected final long accountId;
+    protected final String apiKey;
+    protected volatile HibachiWebSocketClient client;
+    protected volatile HibachiJsonProcessor processor;
+    protected volatile ScheduledExecutorService pingScheduler;
+    protected volatile ScheduledFuture<?> pingTask;
+    protected final AtomicLong listenKeyHolder = new AtomicLong();
+    protected volatile String listenKey;
+
+    public HibachiAccountStreamClient(HibachiConfiguration config, long accountId, String apiKey) {
+        this.config = config;
+        this.accountId = accountId;
+        this.apiKey = apiKey;
+    }
+
+    public synchronized void connect() {
+        if (client != null && client.isOpen()) {
+            return;
+        }
+        try {
+            processor = new HibachiJsonProcessor(this::onClosed);
+            processor.addEventListener(this::onMessage);
+            client = HibachiWebSocketClient.createPrivate(
+                    config.getAccountWsUrl(), String.valueOf(accountId), processor, apiKey, config.getClient());
+            client.connect();
+            // Send stream.start once the socket is open. java-websocket connects synchronously here.
+            sendStreamStart();
+            startPing();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to open Hibachi account WS", e);
+        }
+    }
+
+    public synchronized void disconnect() {
+        stopPing();
+        HibachiWebSocketClient c = client;
+        client = null;
+        if (c != null) {
+            try { c.close(); } catch (Exception ignored) {}
+        }
+        if (processor != null) {
+            processor.shutdown();
+            processor = null;
+        }
+        listenKey = null;
+    }
+
+    public boolean isConnected() {
+        return client != null && client.isOpen();
+    }
+
+    public String getListenKey() {
+        return listenKey;
+    }
+
+    protected void sendStreamStart() {
+        long id = HibachiTradeEnvelope.nextCorrelationId();
+        client.send(HibachiAccountStreamMessages.buildStreamStart(id, accountId));
+    }
+
+    protected void startPing() {
+        long intervalSeconds = Math.max(1L, config.getAccountWsPingSeconds());
+        pingScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "hibachi-account-ping");
+            t.setDaemon(true);
+            return t;
+        });
+        pingTask = pingScheduler.scheduleAtFixedRate(() -> {
+            try {
+                if (client != null && client.isOpen() && listenKey != null) {
+                    long id = HibachiTradeEnvelope.nextCorrelationId();
+                    client.send(HibachiAccountStreamMessages.buildStreamPing(id, accountId, listenKey));
+                }
+            } catch (Exception e) {
+                logger.warn("Hibachi account stream ping failed", e);
+            }
+        }, intervalSeconds, intervalSeconds, TimeUnit.SECONDS);
+    }
+
+    protected void stopPing() {
+        if (pingTask != null) {
+            pingTask.cancel(false);
+            pingTask = null;
+        }
+        if (pingScheduler != null) {
+            pingScheduler.shutdownNow();
+            pingScheduler = null;
+        }
+    }
+
+    protected void onMessage(JsonNode message) {
+        if (message == null) {
+            return;
+        }
+        // Capture listenKey from stream.start response.
+        JsonNode result = message.path("result");
+        if (result.has("listenKey")) {
+            listenKey = result.path("listenKey").asText(null);
+            listenKeyHolder.set(System.currentTimeMillis());
+            logger.info("Hibachi account stream started; listenKey={}", listenKey);
+        }
+    }
+
+    protected void onClosed() {
+        stopPing();
+    }
+}

--- a/implementations/broker-api/hibachi-broker-api-impl/src/main/java/com/fueledbychai/broker/hibachi/HibachiBroker.java
+++ b/implementations/broker-api/hibachi-broker-api-impl/src/main/java/com/fueledbychai/broker/hibachi/HibachiBroker.java
@@ -1,6 +1,5 @@
 package com.fueledbychai.broker.hibachi;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -26,7 +25,6 @@ import com.fueledbychai.util.ExchangeRestApiFactory;
 public class HibachiBroker extends AbstractBasicBroker {
 
     private static final Logger logger = LoggerFactory.getLogger(HibachiBroker.class);
-    private static final BigDecimal DEFAULT_MAX_FEES_PERCENT = new BigDecimal("0.5");
 
     protected final IHibachiRestApi restApi;
     protected final HibachiConfiguration config;
@@ -119,7 +117,7 @@ public class HibachiBroker extends AbstractBasicBroker {
             }
             long nonce = nextNonce();
             HibachiTranslator.SignedRequest request = translator.translatePlace(
-                    order, contract, accountId, nonce, DEFAULT_MAX_FEES_PERCENT, signer);
+                    order, contract, accountId, nonce, config.getOrderMaxFeesPercent(), signer);
             JsonNode response = tradeWs.placeOrder(request.params, request.signature);
             return interpretResponse(response, "placeOrder");
         } catch (Exception e) {
@@ -144,7 +142,7 @@ public class HibachiBroker extends AbstractBasicBroker {
             }
             long nonce = nextNonce();
             HibachiTranslator.SignedRequest request = translator.translateModify(
-                    order, contract, accountId, nonce, DEFAULT_MAX_FEES_PERCENT, signer);
+                    order, contract, accountId, nonce, config.getOrderMaxFeesPercent(), signer);
             JsonNode response = tradeWs.modifyOrder(request.params, request.signature);
             return interpretResponse(response, "modifyOrder");
         } catch (Exception e) {

--- a/implementations/broker-api/hibachi-broker-api-impl/src/main/java/com/fueledbychai/broker/hibachi/HibachiBroker.java
+++ b/implementations/broker-api/hibachi-broker-api-impl/src/main/java/com/fueledbychai/broker/hibachi/HibachiBroker.java
@@ -222,10 +222,11 @@ public class HibachiBroker extends AbstractBasicBroker {
     public BrokerRequestResult cancelAllOrders() {
         checkConnected();
         try {
+            long nonce = nextNonce();
             byte[] bytes = com.fueledbychai.hibachi.common.api.signer.HibachiPayloadPacker
-                    .packCancelAll(nextNonce());
+                    .packCancelAll(nonce);
             String signature = signer.sign(bytes);
-            JsonNode response = tradeWs.cancelAll(nextNonce(), signature);
+            JsonNode response = tradeWs.cancelAll(nonce, signature);
             return interpretResponse(response, "cancelAllOrders");
         } catch (Exception e) {
             logger.error("Hibachi cancelAllOrders failed", e);

--- a/implementations/broker-api/hibachi-broker-api-impl/src/main/java/com/fueledbychai/broker/hibachi/HibachiBroker.java
+++ b/implementations/broker-api/hibachi-broker-api-impl/src/main/java/com/fueledbychai/broker/hibachi/HibachiBroker.java
@@ -1,0 +1,278 @@
+package com.fueledbychai.broker.hibachi;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fueledbychai.broker.AbstractBasicBroker;
+import com.fueledbychai.broker.BrokerRequestResult;
+import com.fueledbychai.broker.BrokerStatus;
+import com.fueledbychai.broker.Position;
+import com.fueledbychai.broker.order.OrderTicket;
+import com.fueledbychai.data.Exchange;
+import com.fueledbychai.data.Ticker;
+import com.fueledbychai.hibachi.common.api.HibachiConfiguration;
+import com.fueledbychai.hibachi.common.api.HibachiContract;
+import com.fueledbychai.hibachi.common.api.IHibachiRestApi;
+import com.fueledbychai.hibachi.common.api.signer.HibachiSignerFactory;
+import com.fueledbychai.hibachi.common.api.signer.IHibachiSigner;
+import com.fueledbychai.util.ExchangeRestApiFactory;
+
+public class HibachiBroker extends AbstractBasicBroker {
+
+    private static final Logger logger = LoggerFactory.getLogger(HibachiBroker.class);
+    private static final BigDecimal DEFAULT_MAX_FEES_PERCENT = new BigDecimal("0.5");
+
+    protected final IHibachiRestApi restApi;
+    protected final HibachiConfiguration config;
+    protected final HibachiTranslator translator;
+    protected final IHibachiSigner signer;
+    protected final long accountId;
+
+    protected final HibachiTradeWebSocketClient tradeWs;
+    protected final HibachiAccountStreamClient accountWs;
+    protected final AtomicLong nextClientOrderId = new AtomicLong(System.currentTimeMillis());
+    protected volatile boolean connected;
+
+    public HibachiBroker() {
+        this(ExchangeRestApiFactory.getPrivateApi(Exchange.HIBACHI, IHibachiRestApi.class),
+                HibachiConfiguration.getInstance(),
+                new HibachiTranslator(),
+                HibachiSignerFactory.create());
+    }
+
+    public HibachiBroker(IHibachiRestApi restApi, HibachiConfiguration config,
+                         HibachiTranslator translator, IHibachiSigner signer) {
+        if (restApi == null) throw new IllegalArgumentException("restApi is required");
+        if (config == null) throw new IllegalArgumentException("config is required");
+        if (translator == null) throw new IllegalArgumentException("translator is required");
+        if (signer == null) throw new IllegalArgumentException("signer is required");
+        this.restApi = restApi;
+        this.config = config;
+        this.translator = translator;
+        this.signer = signer;
+        this.accountId = parseAccountId(config.getAccountId());
+        this.tradeWs = new HibachiTradeWebSocketClient(config, accountId, config.getApiKey());
+        this.accountWs = new HibachiAccountStreamClient(config, accountId, config.getApiKey());
+    }
+
+    @Override
+    public String getBrokerName() {
+        return "Hibachi";
+    }
+
+    @Override
+    public void connect() {
+        if (connected) {
+            return;
+        }
+        try {
+            tradeWs.connect();
+            accountWs.connect();
+            // Eagerly warm contract cache; the trade-WS signer needs contractIds.
+            restApi.getAllContracts();
+            connected = true;
+            logger.info("Hibachi broker connected for accountId={}", accountId);
+        } catch (Exception e) {
+            connected = false;
+            try { tradeWs.disconnect(); } catch (Exception ignored) {}
+            try { accountWs.disconnect(); } catch (Exception ignored) {}
+            throw new IllegalStateException("Failed to connect Hibachi broker", e);
+        }
+    }
+
+    @Override
+    protected void onDisconnect() {
+        connected = false;
+        try { tradeWs.disconnect(); } catch (Exception ignored) {}
+        try { accountWs.disconnect(); } catch (Exception ignored) {}
+    }
+
+    @Override
+    public boolean isConnected() {
+        return connected;
+    }
+
+    @Override
+    public BrokerStatus getBrokerStatus() {
+        return connected ? BrokerStatus.OK : BrokerStatus.UNKNOWN;
+    }
+
+    @Override
+    public BrokerRequestResult placeOrder(OrderTicket order) {
+        checkConnected();
+        if (order == null) {
+            return new BrokerRequestResult(false, true, "order is required",
+                    BrokerRequestResult.FailureType.VALIDATION_FAILED);
+        }
+        try {
+            String symbol = order.getTicker().getSymbol();
+            HibachiContract contract = restApi.getContract(symbol);
+            if (contract == null) {
+                return new BrokerRequestResult(false, true, "Unknown contract: " + symbol,
+                        BrokerRequestResult.FailureType.VALIDATION_FAILED);
+            }
+            long nonce = nextNonce();
+            HibachiTranslator.SignedRequest request = translator.translatePlace(
+                    order, contract, accountId, nonce, DEFAULT_MAX_FEES_PERCENT, signer);
+            JsonNode response = tradeWs.placeOrder(request.params, request.signature);
+            return interpretResponse(response, "placeOrder");
+        } catch (Exception e) {
+            logger.error("Hibachi placeOrder failed", e);
+            return new BrokerRequestResult(false, true, e.getMessage(), BrokerRequestResult.FailureType.UNKNOWN);
+        }
+    }
+
+    @Override
+    public BrokerRequestResult modifyOrder(OrderTicket order) {
+        checkConnected();
+        if (order == null) {
+            return new BrokerRequestResult(false, true, "order is required",
+                    BrokerRequestResult.FailureType.VALIDATION_FAILED);
+        }
+        try {
+            String symbol = order.getTicker().getSymbol();
+            HibachiContract contract = restApi.getContract(symbol);
+            if (contract == null) {
+                return new BrokerRequestResult(false, true, "Unknown contract: " + symbol,
+                        BrokerRequestResult.FailureType.VALIDATION_FAILED);
+            }
+            long nonce = nextNonce();
+            HibachiTranslator.SignedRequest request = translator.translateModify(
+                    order, contract, accountId, nonce, DEFAULT_MAX_FEES_PERCENT, signer);
+            JsonNode response = tradeWs.modifyOrder(request.params, request.signature);
+            return interpretResponse(response, "modifyOrder");
+        } catch (Exception e) {
+            logger.error("Hibachi modifyOrder failed", e);
+            return new BrokerRequestResult(false, true, e.getMessage(), BrokerRequestResult.FailureType.UNKNOWN);
+        }
+    }
+
+    @Override
+    public BrokerRequestResult cancelOrder(OrderTicket order) {
+        checkConnected();
+        if (order == null) {
+            return new BrokerRequestResult(false, true, "order is required",
+                    BrokerRequestResult.FailureType.VALIDATION_FAILED);
+        }
+        try {
+            HibachiTranslator.SignedRequest request = translator.translateCancel(
+                    order, accountId, nextNonce(), signer);
+            JsonNode response = tradeWs.cancelOrder(request.params, request.signature);
+            return interpretResponse(response, "cancelOrder");
+        } catch (Exception e) {
+            logger.error("Hibachi cancelOrder failed", e);
+            return new BrokerRequestResult(false, true, e.getMessage(), BrokerRequestResult.FailureType.UNKNOWN);
+        }
+    }
+
+    @Override
+    public BrokerRequestResult cancelOrder(String id) {
+        if (id == null || id.isBlank()) {
+            return new BrokerRequestResult(false, true, "id is required",
+                    BrokerRequestResult.FailureType.VALIDATION_FAILED);
+        }
+        OrderTicket existing = orderRegistry.getOrderById(id);
+        if (existing == null) {
+            return new BrokerRequestResult(false, true, "Order not found: " + id,
+                    BrokerRequestResult.FailureType.ORDER_NOT_FOUND);
+        }
+        return cancelOrder(existing);
+    }
+
+    @Override
+    public String getNextOrderId() {
+        return String.valueOf(nextClientOrderId.incrementAndGet());
+    }
+
+    @Override
+    public OrderTicket requestOrderStatus(String orderId) {
+        if (orderId == null || orderId.isBlank()) {
+            return null;
+        }
+        return orderRegistry.getOrderById(orderId);
+    }
+
+    @Override
+    public List<OrderTicket> getOpenOrders() {
+        // Best-effort: rely on registry. A production implementation should reconcile
+        // against restApi.getOpenOrders() periodically.
+        List<OrderTicket> open = new ArrayList<>();
+        if (orderRegistry != null) {
+            orderRegistry.getOpenOrders().forEach(open::add);
+        }
+        return open;
+    }
+
+    @Override
+    public List<Position> getAllPositions() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public void cancelAndReplaceOrder(String originalOrderId, OrderTicket newOrder) {
+        cancelOrder(originalOrderId);
+        placeOrder(newOrder);
+    }
+
+    @Override
+    public BrokerRequestResult cancelAllOrders() {
+        checkConnected();
+        try {
+            byte[] bytes = com.fueledbychai.hibachi.common.api.signer.HibachiPayloadPacker
+                    .packCancelAll(nextNonce());
+            String signature = signer.sign(bytes);
+            JsonNode response = tradeWs.cancelAll(nextNonce(), signature);
+            return interpretResponse(response, "cancelAllOrders");
+        } catch (Exception e) {
+            logger.error("Hibachi cancelAllOrders failed", e);
+            return new BrokerRequestResult(false, true, e.getMessage(), BrokerRequestResult.FailureType.UNKNOWN);
+        }
+    }
+
+    @Override
+    public BrokerRequestResult cancelAllOrders(Ticker ticker) {
+        // Hibachi does not expose a per-symbol cancel-all on the trade WS — fall back to the
+        // global cancel; callers needing per-symbol must iterate open orders themselves.
+        return cancelAllOrders();
+    }
+
+    protected BrokerRequestResult interpretResponse(JsonNode response, String op) {
+        if (response == null) {
+            return new BrokerRequestResult(false, true, op + " returned null", BrokerRequestResult.FailureType.UNKNOWN);
+        }
+        if (response.has("error") && !response.path("error").isNull()) {
+            String msg = response.path("error").toString();
+            return new BrokerRequestResult(false, true, msg, BrokerRequestResult.FailureType.UNKNOWN);
+        }
+        return new BrokerRequestResult();
+    }
+
+    protected long nextNonce() {
+        // Microseconds since epoch, matches Python SDK (api.py:1315 etc.).
+        return System.currentTimeMillis() * 1_000L;
+    }
+
+    protected void checkConnected() {
+        if (!connected) {
+            throw new IllegalStateException("Hibachi broker is not connected");
+        }
+    }
+
+    private static long parseAccountId(String value) {
+        if (value == null || value.isBlank()) {
+            return 0L;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "Invalid " + HibachiConfiguration.HIBACHI_ACCOUNT_ID + ": " + value, e);
+        }
+    }
+}

--- a/implementations/broker-api/hibachi-broker-api-impl/src/main/java/com/fueledbychai/broker/hibachi/HibachiBrokerProvider.java
+++ b/implementations/broker-api/hibachi-broker-api-impl/src/main/java/com/fueledbychai/broker/hibachi/HibachiBrokerProvider.java
@@ -1,0 +1,18 @@
+package com.fueledbychai.broker.hibachi;
+
+import com.fueledbychai.broker.BrokerProvider;
+import com.fueledbychai.broker.IBroker;
+import com.fueledbychai.data.Exchange;
+
+public class HibachiBrokerProvider implements BrokerProvider {
+
+    @Override
+    public Exchange getExchange() {
+        return Exchange.HIBACHI;
+    }
+
+    @Override
+    public IBroker getBroker() {
+        return new HibachiBroker();
+    }
+}

--- a/implementations/broker-api/hibachi-broker-api-impl/src/main/java/com/fueledbychai/broker/hibachi/HibachiTradeWebSocketClient.java
+++ b/implementations/broker-api/hibachi-broker-api-impl/src/main/java/com/fueledbychai/broker/hibachi/HibachiTradeWebSocketClient.java
@@ -1,0 +1,204 @@
+package com.fueledbychai.broker.hibachi;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fueledbychai.hibachi.common.api.HibachiConfiguration;
+import com.fueledbychai.hibachi.common.api.ws.HibachiJsonProcessor;
+import com.fueledbychai.hibachi.common.api.ws.HibachiWebSocketClient;
+import com.fueledbychai.hibachi.common.api.ws.trade.HibachiOrderStatusListener;
+import com.fueledbychai.hibachi.common.api.ws.trade.HibachiOrderStatusUpdate;
+import com.fueledbychai.hibachi.common.api.ws.trade.HibachiTradeEnvelope;
+
+/**
+ * Trade WebSocket client for Hibachi.
+ *
+ * <p>Owns:
+ * <ul>
+ *   <li>The persistent trade WS connection (signed-payload order ops)</li>
+ *   <li>A correlation map ({@code id} → {@link CompletableFuture}) for request/response</li>
+ *   <li>A small fanout for unsolicited order-status frames</li>
+ * </ul>
+ *
+ * <p>Order placement / modification / cancellation use the trade WS from day one (per the
+ * project decision; see {@code memory/project_hibachi.md}). REST is used only for read-only
+ * lookups in the broker layer.
+ */
+public class HibachiTradeWebSocketClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(HibachiTradeWebSocketClient.class);
+    private static final long DEFAULT_REQUEST_TIMEOUT_MILLIS = 10_000L;
+
+    protected final HibachiConfiguration config;
+    protected final long accountId;
+    protected final String apiKey;
+    protected final Map<Long, CompletableFuture<JsonNode>> pendingRequests = new ConcurrentHashMap<>();
+    protected volatile HibachiWebSocketClient client;
+    protected volatile HibachiJsonProcessor processor;
+    protected volatile HibachiOrderStatusListener orderStatusListener;
+    protected volatile Consumer<JsonNode> rawListener;
+
+    public HibachiTradeWebSocketClient(HibachiConfiguration config, long accountId, String apiKey) {
+        this.config = config;
+        this.accountId = accountId;
+        this.apiKey = apiKey;
+    }
+
+    public synchronized void connect() {
+        if (client != null && client.isOpen()) {
+            return;
+        }
+        try {
+            processor = new HibachiJsonProcessor(this::onClosed);
+            processor.addEventListener(this::onMessage);
+            client = HibachiWebSocketClient.createPrivate(
+                    config.getTradeWsUrl(), String.valueOf(accountId), processor, apiKey, config.getClient());
+            client.connect();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to open Hibachi trade WS", e);
+        }
+    }
+
+    public synchronized void disconnect() {
+        HibachiWebSocketClient c = client;
+        client = null;
+        if (c != null) {
+            try { c.close(); } catch (Exception ignored) {}
+        }
+        if (processor != null) {
+            processor.shutdown();
+            processor = null;
+        }
+        for (CompletableFuture<JsonNode> pending : pendingRequests.values()) {
+            pending.completeExceptionally(new IllegalStateException("trade WS disconnected"));
+        }
+        pendingRequests.clear();
+    }
+
+    public boolean isConnected() {
+        return client != null && client.isOpen();
+    }
+
+    public void setOrderStatusListener(HibachiOrderStatusListener listener) {
+        this.orderStatusListener = listener;
+    }
+
+    public void setRawMessageListener(Consumer<JsonNode> listener) {
+        this.rawListener = listener;
+    }
+
+    /**
+     * Sends an {@code order.place} request and awaits the response.
+     */
+    public JsonNode placeOrder(Map<String, Object> params, String signature) throws Exception {
+        long id = HibachiTradeEnvelope.nextCorrelationId();
+        return await(id, HibachiTradeEnvelope.buildPlace(id, params, signature));
+    }
+
+    /** Sends an {@code order.modify} request and awaits the response. */
+    public JsonNode modifyOrder(Map<String, Object> params, String signature) throws Exception {
+        long id = HibachiTradeEnvelope.nextCorrelationId();
+        return await(id, HibachiTradeEnvelope.buildModify(id, params, signature));
+    }
+
+    /** Sends an {@code order.cancel} request and awaits the response. */
+    public JsonNode cancelOrder(Map<String, Object> params, String signature) throws Exception {
+        long id = HibachiTradeEnvelope.nextCorrelationId();
+        return await(id, HibachiTradeEnvelope.buildCancel(id, params, signature));
+    }
+
+    /** Sends an {@code orders.cancel} (cancel-all) request and awaits the response. */
+    public JsonNode cancelAll(long nonce, String signature) throws Exception {
+        long id = HibachiTradeEnvelope.nextCorrelationId();
+        return await(id, HibachiTradeEnvelope.buildCancelAll(id, accountId, nonce, signature));
+    }
+
+    /** Queries the status of a single order; no signature. */
+    public JsonNode orderStatus(String orderId) throws Exception {
+        long id = HibachiTradeEnvelope.nextCorrelationId();
+        return await(id, HibachiTradeEnvelope.buildOrderStatus(id, accountId, orderId));
+    }
+
+    /** Queries the status of all open orders; no signature. */
+    public JsonNode ordersStatus() throws Exception {
+        long id = HibachiTradeEnvelope.nextCorrelationId();
+        return await(id, HibachiTradeEnvelope.buildOrdersStatus(id, accountId));
+    }
+
+    /** Sends {@code orders.enableCancelOnDisconnect}. */
+    public void enableCancelOnDisconnect(long nonce) {
+        long id = HibachiTradeEnvelope.nextCorrelationId();
+        send(HibachiTradeEnvelope.buildEnableCancelOnDisconnect(id, nonce));
+    }
+
+    protected JsonNode await(long id, String message) throws Exception {
+        CompletableFuture<JsonNode> future = new CompletableFuture<>();
+        pendingRequests.put(id, future);
+        try {
+            send(message);
+            return future.get(DEFAULT_REQUEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException te) {
+            pendingRequests.remove(id);
+            throw new IllegalStateException("Timed out waiting for Hibachi trade WS response id=" + id, te);
+        }
+    }
+
+    protected void send(String message) {
+        HibachiWebSocketClient c = client;
+        if (c == null || !c.isOpen()) {
+            throw new IllegalStateException("Hibachi trade WS is not connected");
+        }
+        c.send(message);
+    }
+
+    protected void onMessage(JsonNode message) {
+        if (message == null) {
+            return;
+        }
+        if (message.has("id")) {
+            long id = message.path("id").asLong();
+            CompletableFuture<JsonNode> pending = pendingRequests.remove(id);
+            if (pending != null) {
+                pending.complete(message);
+            }
+        }
+        Consumer<JsonNode> raw = rawListener;
+        if (raw != null) {
+            try { raw.accept(message); } catch (Exception e) { logger.warn("trade WS raw listener failed", e); }
+        }
+        HibachiOrderStatusListener listener = orderStatusListener;
+        if (listener != null) {
+            HibachiOrderStatusUpdate update = parseOrderStatusUpdate(message);
+            if (update != null) {
+                try { listener.onOrderStatus(update); } catch (Exception e) {
+                    logger.warn("order status listener failed", e);
+                }
+            }
+        }
+    }
+
+    protected HibachiOrderStatusUpdate parseOrderStatusUpdate(JsonNode message) {
+        // Best-effort parse of unsolicited order-status frames. Exact shape is
+        // not fully specified in the docs — extend this when first observed
+        // against testnet.
+        if (message == null || !message.has("orderId")) {
+            return null;
+        }
+        return null;
+    }
+
+    protected void onClosed() {
+        for (CompletableFuture<JsonNode> pending : pendingRequests.values()) {
+            pending.completeExceptionally(new IllegalStateException("trade WS closed"));
+        }
+        pendingRequests.clear();
+    }
+}

--- a/implementations/broker-api/hibachi-broker-api-impl/src/main/java/com/fueledbychai/broker/hibachi/HibachiTranslator.java
+++ b/implementations/broker-api/hibachi-broker-api-impl/src/main/java/com/fueledbychai/broker/hibachi/HibachiTranslator.java
@@ -1,0 +1,194 @@
+package com.fueledbychai.broker.hibachi;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.fueledbychai.broker.order.OrderTicket;
+import com.fueledbychai.broker.order.TradeDirection;
+import com.fueledbychai.hibachi.common.api.HibachiContract;
+import com.fueledbychai.hibachi.common.api.order.HibachiOrderFlag;
+import com.fueledbychai.hibachi.common.api.order.HibachiOrderType;
+import com.fueledbychai.hibachi.common.api.order.HibachiSide;
+import com.fueledbychai.hibachi.common.api.signer.HibachiPayloadPacker;
+import com.fueledbychai.hibachi.common.api.signer.IHibachiSigner;
+
+/**
+ * Translates {@link OrderTicket}s to Hibachi trade-WebSocket payloads + signatures.
+ *
+ * <p>For PLACE/MODIFY: produces (signedBytes, jsonParams) where signedBytes is the byte
+ * layout from {@link HibachiPayloadPacker} and jsonParams is the trade-WS {@code params}
+ * map (full-precision strings via {@link BigDecimal#toPlainString()}).
+ */
+public class HibachiTranslator {
+
+    public static class SignedRequest {
+        public final byte[] signedBytes;
+        public final Map<String, Object> params;
+        public final String signature;
+
+        public SignedRequest(byte[] signedBytes, Map<String, Object> params, String signature) {
+            this.signedBytes = signedBytes;
+            this.params = params;
+            this.signature = signature;
+        }
+    }
+
+    public SignedRequest translatePlace(OrderTicket order,
+                                        HibachiContract contract,
+                                        long accountId,
+                                        long nonce,
+                                        BigDecimal maxFeesPercent,
+                                        IHibachiSigner signer) {
+        if (order == null) throw new IllegalArgumentException("order is required");
+        if (contract == null) throw new IllegalArgumentException("contract is required");
+        if (signer == null) throw new IllegalArgumentException("signer is required");
+
+        HibachiSide side = toSide(order.getTradeDirection());
+        HibachiOrderType orderType = toOrderType(order);
+        BigDecimal price = orderType == HibachiOrderType.LIMIT ? order.getLimitPrice() : null;
+        BigDecimal qty = order.getSize();
+        if (qty == null || qty.signum() <= 0) {
+            throw new IllegalArgumentException("order size must be > 0");
+        }
+
+        byte[] signedBytes = HibachiPayloadPacker.packPlaceOrder(nonce, contract, qty, side, price, maxFeesPercent);
+        String signature = signer.sign(signedBytes);
+
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("nonce", nonce);
+        params.put("symbol", contract.getSymbol());
+        params.put("quantity", qty.toPlainString());
+        params.put("orderType", orderType.getWireValue());
+        params.put("side", side.getWireValue());
+        params.put("maxFeesPercent", maxFeesPercent.toPlainString());
+        params.put("signature", signature);
+        if (price != null) {
+            params.put("price", price.toPlainString());
+        }
+        HibachiOrderFlag flag = toFlag(order);
+        if (flag != null) {
+            params.put("orderFlags", flag.getWireValue());
+        }
+        params.put("accountId", accountId);
+        return new SignedRequest(signedBytes, params, signature);
+    }
+
+    public SignedRequest translateModify(OrderTicket order,
+                                         HibachiContract contract,
+                                         long accountId,
+                                         long nonce,
+                                         BigDecimal maxFeesPercent,
+                                         IHibachiSigner signer) {
+        if (order == null) throw new IllegalArgumentException("order is required");
+        if (contract == null) throw new IllegalArgumentException("contract is required");
+        if (signer == null) throw new IllegalArgumentException("signer is required");
+
+        HibachiSide side = toSide(order.getTradeDirection());
+        HibachiOrderType orderType = toOrderType(order);
+        BigDecimal price = orderType == HibachiOrderType.LIMIT ? order.getLimitPrice() : null;
+        BigDecimal qty = order.getSize();
+        if (qty == null || qty.signum() <= 0) {
+            throw new IllegalArgumentException("order size must be > 0");
+        }
+
+        byte[] signedBytes = HibachiPayloadPacker.packPlaceOrder(nonce, contract, qty, side, price, maxFeesPercent);
+        String signature = signer.sign(signedBytes);
+
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("nonce", nonce);
+        params.put("maxFeesPercent", maxFeesPercent.toPlainString());
+        if (order.getOrderId() != null && !order.getOrderId().isBlank()) {
+            params.put("orderId", order.getOrderId());
+        }
+        // SDK quirk: emit both `quantity` and `updatedQuantity` (same value); same for price.
+        params.put("quantity", qty.toPlainString());
+        params.put("updatedQuantity", qty.toPlainString());
+        if (price != null) {
+            params.put("price", price.toPlainString());
+            params.put("updatedPrice", price.toPlainString());
+        }
+        HibachiOrderFlag flag = toFlag(order);
+        if (flag != null) {
+            params.put("orderFlags", flag.getWireValue());
+        }
+        params.put("accountId", accountId);
+        return new SignedRequest(signedBytes, params, signature);
+    }
+
+    public SignedRequest translateCancel(OrderTicket order,
+                                         long accountId,
+                                         Long nonce,
+                                         IHibachiSigner signer) {
+        if (order == null) throw new IllegalArgumentException("order is required");
+        if (signer == null) throw new IllegalArgumentException("signer is required");
+
+        Long orderId = parseLongOrNull(order.getOrderId());
+        byte[] signedBytes = HibachiPayloadPacker.packCancelOrder(orderId, nonce);
+        String signature = signer.sign(signedBytes);
+
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("accountId", accountId);
+        if (orderId != null) {
+            params.put("orderId", String.valueOf(orderId));
+        } else if (nonce != null) {
+            params.put("nonce", String.valueOf(nonce));
+        }
+        return new SignedRequest(signedBytes, params, signature);
+    }
+
+    public HibachiSide toSide(TradeDirection direction) {
+        if (direction == null) {
+            throw new IllegalArgumentException("trade direction is required");
+        }
+        // Map LONG/BUY → BID, SHORT/SELL → ASK.
+        switch (direction) {
+            case BUY:
+            case BUY_TO_COVER:
+                return HibachiSide.BID;
+            case SELL:
+            case SELL_SHORT:
+                return HibachiSide.ASK;
+            default:
+                throw new IllegalArgumentException("Unsupported trade direction: " + direction);
+        }
+    }
+
+    public HibachiOrderType toOrderType(OrderTicket order) {
+        if (order == null || order.getType() == null) {
+            return HibachiOrderType.MARKET;
+        }
+        switch (order.getType()) {
+            case LIMIT:
+            case STOP_LIMIT:
+                return HibachiOrderType.LIMIT;
+            case MARKET:
+            case STOP:
+            default:
+                return HibachiOrderType.MARKET;
+        }
+    }
+
+    public HibachiOrderFlag toFlag(OrderTicket order) {
+        if (order == null || order.getDuration() == null) {
+            return null;
+        }
+        switch (order.getDuration()) {
+            case IMMEDIATE_OR_CANCEL:
+                return HibachiOrderFlag.IOC;
+            default:
+                return null;
+        }
+    }
+
+    private static Long parseLongOrNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/implementations/broker-api/hibachi-broker-api-impl/src/main/resources/META-INF/services/com.fueledbychai.broker.BrokerProvider
+++ b/implementations/broker-api/hibachi-broker-api-impl/src/main/resources/META-INF/services/com.fueledbychai.broker.BrokerProvider
@@ -1,0 +1,1 @@
+com.fueledbychai.broker.hibachi.HibachiBrokerProvider

--- a/implementations/broker-api/pom.xml
+++ b/implementations/broker-api/pom.xml
@@ -46,5 +46,6 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         <module>bybit-broker-api-impl</module>
         <module>drift-broker-api-impl</module>
         <module>aster-broker-api-impl</module>
+        <module>hibachi-broker-api-impl</module>
     </modules>
 </project>

--- a/implementations/market-data-api/hibachi-market-data-impl/pom.xml
+++ b/implementations/market-data-api/hibachi-market-data-impl/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>market-data-api</artifactId>
+        <groupId>com.fueledbychai</groupId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>hibachi-market-data-impl</artifactId>
+    <version>0.2.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>fueledbychai-market-data-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibachi-common-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M9</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/implementations/market-data-api/hibachi-market-data-impl/src/main/java/com/fueledbychai/marketdata/hibachi/HibachiQuoteEngine.java
+++ b/implementations/market-data-api/hibachi-market-data-impl/src/main/java/com/fueledbychai/marketdata/hibachi/HibachiQuoteEngine.java
@@ -11,6 +11,10 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +57,10 @@ public class HibachiQuoteEngine extends QuoteEngine {
 
     private static final Logger logger = LoggerFactory.getLogger(HibachiQuoteEngine.class);
     private static final ZoneId UTC = ZoneId.of("UTC");
+    private static final java.math.MathContext MC = java.math.MathContext.DECIMAL64;
+    private static final BigDecimal HOURS_PER_YEAR = BigDecimal.valueOf(24L * 365L);
+    private static final BigDecimal PERCENT_MULTIPLIER = BigDecimal.valueOf(100);
+    private static final BigDecimal BPS_MULTIPLIER = BigDecimal.valueOf(10000);
 
     protected final IHibachiRestApi restApi;
     protected final ITickerRegistry tickerRegistry;
@@ -62,6 +70,10 @@ public class HibachiQuoteEngine extends QuoteEngine {
     protected volatile HibachiWebSocketClient marketClient;
     protected volatile HibachiJsonProcessor marketProcessor;
     protected volatile boolean started = false;
+
+    protected final Set<String> volumePollingSymbols = ConcurrentHashMap.newKeySet();
+    protected volatile ScheduledExecutorService volumeScheduler;
+    protected volatile ScheduledFuture<?> volumeTask;
 
     public HibachiQuoteEngine() {
         this(ExchangeRestApiFactory.getPublicApi(Exchange.HIBACHI, IHibachiRestApi.class),
@@ -118,6 +130,15 @@ public class HibachiQuoteEngine extends QuoteEngine {
     public void stopEngine() {
         started = false;
         activeSubscriptions.clear();
+        volumePollingSymbols.clear();
+        if (volumeTask != null) {
+            volumeTask.cancel(false);
+            volumeTask = null;
+        }
+        if (volumeScheduler != null) {
+            volumeScheduler.shutdownNow();
+            volumeScheduler = null;
+        }
         HibachiWebSocketClient client = marketClient;
         marketClient = null;
         HibachiJsonProcessor processor = marketProcessor;
@@ -138,6 +159,7 @@ public class HibachiQuoteEngine extends QuoteEngine {
         for (String topic : HibachiTopicRouter.LEVEL1_TOPICS) {
             subscribeTopic(ticker, topic);
         }
+        startVolumePolling(ticker);
     }
 
     @Override
@@ -187,7 +209,13 @@ public class HibachiQuoteEngine extends QuoteEngine {
             marketProcessor.addEventListener(this::onMarketMessage);
             marketClient = HibachiWebSocketClient.createMarket(
                     config.getMarketWsUrl(), marketProcessor, config.getClient(), null);
-            marketClient.connect();
+            if (!marketClient.connectBlocking(10, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Timed out connecting to Hibachi market WS at "
+                        + config.getMarketWsUrl());
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted connecting to Hibachi market WS", ie);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to create Hibachi market WS client", e);
         }
@@ -201,7 +229,10 @@ public class HibachiQuoteEngine extends QuoteEngine {
         try {
             String msg = HibachiMarketSubscribeMessage.subscribe(ticker.getSymbol(), topic);
             if (marketClient != null && marketClient.isOpen()) {
+                logger.info("Hibachi WS send: {}", msg);
                 marketClient.send(msg);
+            } else {
+                logger.warn("Hibachi WS not open; dropping subscribe for {} {}", ticker.getSymbol(), topic);
             }
         } catch (Exception e) {
             logger.warn("Failed to send subscribe for {} {}", ticker.getSymbol(), topic, e);
@@ -212,7 +243,9 @@ public class HibachiQuoteEngine extends QuoteEngine {
         if (!started) {
             return;
         }
-        logger.warn("Hibachi market WS closed; will not auto-reconnect in this engine version");
+        logger.warn("Hibachi market WS closed; auto-reconnect is disabled in this engine version because "
+                + "the engine does not rebuild the websocket/subscription state after disconnect. "
+                + "Manual recovery is required before market data will resume.");
     }
 
     protected void onMarketMessage(JsonNode message) {
@@ -222,10 +255,13 @@ public class HibachiQuoteEngine extends QuoteEngine {
         String topic = message.path("topic").asText("");
         String symbol = message.path("symbol").asText("");
         if (topic.isEmpty()) {
+            logger.info("Hibachi WS recv (no topic): {}", message);
             return;
         }
+        logger.info("Hibachi WS dispatch topic={} symbol={}", topic, symbol);
         Ticker ticker = lookupTicker(symbol);
         if (ticker == null) {
+            logger.warn("Hibachi WS no ticker for symbol={} topic={}", symbol, topic);
             return;
         }
         try {
@@ -234,6 +270,7 @@ public class HibachiQuoteEngine extends QuoteEngine {
                 case HibachiTopicRouter.TOPIC_MARK_PRICE -> onMarkPriceUpdate(ticker, message);
                 case HibachiTopicRouter.TOPIC_ORDERBOOK -> onOrderBookUpdate(ticker, message);
                 case HibachiTopicRouter.TOPIC_TRADES -> onTradesUpdate(ticker, message);
+                case HibachiTopicRouter.TOPIC_FUNDING_RATE_ESTIMATION -> onFundingRateUpdate(ticker, message);
                 default -> { /* unhandled topic */ }
             }
         } catch (Exception e) {
@@ -242,15 +279,16 @@ public class HibachiQuoteEngine extends QuoteEngine {
     }
 
     protected void onAskBidUpdate(Ticker ticker, JsonNode message) {
-        Level1Quote quote = new Level1Quote(ticker, toTimestamp(message, "timestamp"));
+        JsonNode data = message.path("data");
+        Level1Quote quote = new Level1Quote(ticker, toTimestamp(message, "timestamp_ms"));
         boolean any = false;
-        BigDecimal bid = decimal(message, "bidPrice");
+        BigDecimal bid = decimal(data, "bidPrice");
         if (bid != null) { quote.addQuote(QuoteType.BID, bid); any = true; }
-        BigDecimal bidSize = decimal(message, "bidSize");
+        BigDecimal bidSize = decimal(data, "bidSize");
         if (bidSize != null) { quote.addQuote(QuoteType.BID_SIZE, bidSize); any = true; }
-        BigDecimal ask = decimal(message, "askPrice");
+        BigDecimal ask = decimal(data, "askPrice");
         if (ask != null) { quote.addQuote(QuoteType.ASK, ask); any = true; }
-        BigDecimal askSize = decimal(message, "askSize");
+        BigDecimal askSize = decimal(data, "askSize");
         if (askSize != null) { quote.addQuote(QuoteType.ASK_SIZE, askSize); any = true; }
         if (any) {
             fireLevel1Quote(quote);
@@ -258,9 +296,10 @@ public class HibachiQuoteEngine extends QuoteEngine {
     }
 
     protected void onMarkPriceUpdate(Ticker ticker, JsonNode message) {
-        Level1Quote quote = new Level1Quote(ticker, toTimestamp(message, "timestamp"));
+        JsonNode data = message.path("data");
+        Level1Quote quote = new Level1Quote(ticker, toTimestamp(message, "timestamp_ms"));
         boolean any = false;
-        BigDecimal mark = firstDecimal(message, "markPrice", "price");
+        BigDecimal mark = firstDecimal(data, "markPrice", "price");
         if (mark != null) { quote.addQuote(QuoteType.MARK_PRICE, mark); any = true; }
         if (any) {
             fireLevel1Quote(quote);
@@ -268,40 +307,119 @@ public class HibachiQuoteEngine extends QuoteEngine {
     }
 
     protected void onOrderBookUpdate(Ticker ticker, JsonNode message) {
-        List<OrderBook.PriceLevel> bids = parseLevels(message.path("bids"));
-        List<OrderBook.PriceLevel> asks = parseLevels(message.path("asks"));
+        JsonNode data = message.path("data");
+        List<OrderBook.PriceLevel> bids = parseLevels(data.path("bid").path("levels"));
+        List<OrderBook.PriceLevel> asks = parseLevels(data.path("ask").path("levels"));
         if (bids.isEmpty() && asks.isEmpty()) {
             return;
         }
         OrderBook orderBook = new OrderBook(ticker, ticker.getMinimumTickSize());
-        ZonedDateTime timestamp = toTimestamp(message, "timestamp");
+        ZonedDateTime timestamp = toTimestamp(message, "timestamp_ms");
         orderBook.updateFromSnapshot(bids, asks, timestamp);
         fireMarketDepthQuote(new Level2Quote(ticker, orderBook, timestamp));
     }
 
     protected void onTradesUpdate(Ticker ticker, JsonNode message) {
-        JsonNode trades = message.path("trades");
-        if (!trades.isArray()) {
-            // Single-trade payload?
-            emitTrade(ticker, message);
+        JsonNode data = message.path("data");
+        // Hibachi may wrap a single trade as {"trade":{...}} or batch as {"trades":[...]}
+        JsonNode singleTrade = data.path("trade");
+        if (singleTrade.isObject()) {
+            emitTrade(ticker, singleTrade);
             return;
         }
-        for (JsonNode trade : trades) {
-            emitTrade(ticker, trade);
+        JsonNode trades = data.path("trades");
+        if (trades.isArray()) {
+            for (JsonNode trade : trades) {
+                emitTrade(ticker, trade);
+            }
+            return;
         }
+        emitTrade(ticker, data);
     }
 
     protected void emitTrade(Ticker ticker, JsonNode trade) {
         BigDecimal price = decimal(trade, "price");
         BigDecimal size = firstDecimal(trade, "quantity", "size");
         if (price == null || size == null) {
+            logger.info("Hibachi trade missing fields: price={} size={} raw={}", price, size, trade);
             return;
         }
-        String sideStr = trade.path("side").asText("BID").toUpperCase();
+        String sideStr = firstString(trade, "takerSide", "side").toUpperCase();
         OrderFlow.Side side = "ASK".equals(sideStr) || "SELL".equals(sideStr)
                 ? OrderFlow.Side.SELL : OrderFlow.Side.BUY;
-        OrderFlow flow = new OrderFlow(ticker, price, size, side, toTimestamp(trade, "timestamp"));
+        ZonedDateTime ts = toTimestamp(trade, "timestamp_ms");
+        OrderFlow flow = new OrderFlow(ticker, price, size, side, ts);
         fireOrderFlow(flow);
+
+        Level1Quote lastQuote = new Level1Quote(ticker, ts);
+        lastQuote.addQuote(QuoteType.LAST, price);
+        lastQuote.addQuote(QuoteType.LAST_SIZE, size);
+        fireLevel1Quote(lastQuote);
+    }
+
+    protected void onFundingRateUpdate(Ticker ticker, JsonNode message) {
+        JsonNode data = message.path("data");
+        BigDecimal rate = decimal(data, "estimatedFundingRate");
+        if (rate == null) {
+            rate = decimal(data.path("fundingRateEstimation"), "estimatedFundingRate");
+        }
+        if (rate == null) {
+            logger.info("Hibachi funding rate missing estimatedFundingRate: {}", data);
+            return;
+        }
+        int fundingInterval = ticker.getFundingRateInterval();
+        if (fundingInterval <= 0) {
+            fundingInterval = 8;
+        }
+        BigDecimal hourlyRate = rate.divide(BigDecimal.valueOf(fundingInterval), MC);
+        BigDecimal annualizedPercent = hourlyRate.multiply(HOURS_PER_YEAR).multiply(PERCENT_MULTIPLIER, MC);
+        BigDecimal hourlyBps = hourlyRate.multiply(BPS_MULTIPLIER, MC);
+        Level1Quote quote = new Level1Quote(ticker, toTimestamp(message, "timestamp_ms"));
+        quote.addQuote(QuoteType.FUNDING_RATE_APR, annualizedPercent);
+        quote.addQuote(QuoteType.FUNDING_RATE_HOURLY_BPS, hourlyBps);
+        fireLevel1Quote(quote);
+    }
+
+    protected synchronized void startVolumePolling(Ticker ticker) {
+        String symbol = ticker.getSymbol();
+        if (!volumePollingSymbols.add(symbol)) {
+            return;
+        }
+        if (volumeScheduler == null) {
+            volumeScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "hibachi-volume-poll");
+                t.setDaemon(true);
+                return t;
+            });
+            volumeTask = volumeScheduler.scheduleAtFixedRate(
+                    this::pollVolume, 0, 1, TimeUnit.SECONDS);
+        }
+    }
+
+    protected void pollVolume() {
+        for (String symbol : volumePollingSymbols) {
+            try {
+                JsonNode stats = restApi.getMarketStats(symbol);
+                if (stats == null || stats.isMissingNode()) {
+                    continue;
+                }
+                Ticker ticker = lookupTicker(symbol);
+                if (ticker == null) {
+                    continue;
+                }
+                Level1Quote quote = new Level1Quote(ticker, ZonedDateTime.now(UTC));
+                boolean any = false;
+                BigDecimal volume = decimal(stats, "volume24h");
+                if (volume != null) { quote.addQuote(QuoteType.VOLUME, volume); any = true; }
+                BigDecimal volumeNotional = decimal(stats, "volumeNotional24h");
+                if (volumeNotional != null) { quote.addQuote(QuoteType.VOLUME_NOTIONAL, volumeNotional); any = true; }
+                if (any) {
+                    fireLevel1Quote(quote);
+                }
+            } catch (Exception e) {
+                logger.debug("Failed to poll volume for {}", symbol, e);
+            }
+        }
     }
 
     protected Ticker lookupTicker(String symbol) {
@@ -337,10 +455,18 @@ public class HibachiQuoteEngine extends QuoteEngine {
             return out;
         }
         for (JsonNode lvl : arr) {
-            if (!lvl.isArray() || lvl.size() < 2) continue;
             try {
-                BigDecimal price = new BigDecimal(lvl.get(0).asText());
-                double size = Double.parseDouble(lvl.get(1).asText());
+                BigDecimal price;
+                double size;
+                if (lvl.isArray() && lvl.size() >= 2) {
+                    price = new BigDecimal(lvl.get(0).asText());
+                    size = Double.parseDouble(lvl.get(1).asText());
+                } else if (lvl.isObject()) {
+                    price = new BigDecimal(lvl.path("price").asText());
+                    size = Double.parseDouble(lvl.path("quantity").asText());
+                } else {
+                    continue;
+                }
                 out.add(new OrderBook.PriceLevel(price, size));
             } catch (NumberFormatException ignored) {
             }
@@ -380,6 +506,15 @@ public class HibachiQuoteEngine extends QuoteEngine {
             }
         }
         return null;
+    }
+
+    protected String firstString(JsonNode message, String... fields) {
+        if (message == null) return "";
+        for (String f : fields) {
+            String v = message.path(f).asText("");
+            if (!v.isBlank()) return v;
+        }
+        return "";
     }
 
     protected void requireTicker(Ticker ticker) {

--- a/implementations/market-data-api/hibachi-market-data-impl/src/main/java/com/fueledbychai/marketdata/hibachi/HibachiQuoteEngine.java
+++ b/implementations/market-data-api/hibachi-market-data-impl/src/main/java/com/fueledbychai/marketdata/hibachi/HibachiQuoteEngine.java
@@ -1,0 +1,420 @@
+package com.fueledbychai.marketdata.hibachi;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fueledbychai.data.Exchange;
+import com.fueledbychai.data.Ticker;
+import com.fueledbychai.hibachi.common.api.HibachiConfiguration;
+import com.fueledbychai.hibachi.common.api.IHibachiRestApi;
+import com.fueledbychai.hibachi.common.api.ws.HibachiJsonProcessor;
+import com.fueledbychai.hibachi.common.api.ws.HibachiMarketSubscribeMessage;
+import com.fueledbychai.hibachi.common.api.ws.HibachiTopicRouter;
+import com.fueledbychai.hibachi.common.api.ws.HibachiWebSocketClient;
+import com.fueledbychai.marketdata.ILevel1Quote;
+import com.fueledbychai.marketdata.Level1Quote;
+import com.fueledbychai.marketdata.Level1QuoteListener;
+import com.fueledbychai.marketdata.Level2Quote;
+import com.fueledbychai.marketdata.Level2QuoteListener;
+import com.fueledbychai.marketdata.OrderBook;
+import com.fueledbychai.marketdata.OrderFlow;
+import com.fueledbychai.marketdata.OrderFlowListener;
+import com.fueledbychai.marketdata.QuoteEngine;
+import com.fueledbychai.marketdata.QuoteType;
+import com.fueledbychai.util.ExchangeRestApiFactory;
+import com.fueledbychai.util.ITickerRegistry;
+import com.fueledbychai.util.TickerRegistryFactory;
+
+/**
+ * Hibachi market-data quote engine.
+ *
+ * <p>Maintains a single shared market WebSocket connection (Hibachi multiplexes topics on
+ * one connection). Subscriptions map to:
+ * <ul>
+ *   <li><b>L1</b> = {@code ask_bid_price} + {@code mark_price}</li>
+ *   <li><b>L2</b> = {@code orderbook}</li>
+ *   <li><b>OrderFlow</b> = {@code trades}</li>
+ * </ul>
+ */
+public class HibachiQuoteEngine extends QuoteEngine {
+
+    private static final Logger logger = LoggerFactory.getLogger(HibachiQuoteEngine.class);
+    private static final ZoneId UTC = ZoneId.of("UTC");
+
+    protected final IHibachiRestApi restApi;
+    protected final ITickerRegistry tickerRegistry;
+    protected final HibachiConfiguration config;
+    protected final Set<SubKey> activeSubscriptions = ConcurrentHashMap.newKeySet();
+
+    protected volatile HibachiWebSocketClient marketClient;
+    protected volatile HibachiJsonProcessor marketProcessor;
+    protected volatile boolean started = false;
+
+    public HibachiQuoteEngine() {
+        this(ExchangeRestApiFactory.getPublicApi(Exchange.HIBACHI, IHibachiRestApi.class),
+                TickerRegistryFactory.getInstance(Exchange.HIBACHI),
+                HibachiConfiguration.getInstance());
+        logger.info("Hibachi market WS URL: {}", config.getMarketWsUrl());
+    }
+
+    protected HibachiQuoteEngine(IHibachiRestApi restApi, ITickerRegistry tickerRegistry,
+                                 HibachiConfiguration config) {
+        if (restApi == null) throw new IllegalArgumentException("restApi is required");
+        if (tickerRegistry == null) throw new IllegalArgumentException("tickerRegistry is required");
+        if (config == null) throw new IllegalArgumentException("config is required");
+        this.restApi = restApi;
+        this.tickerRegistry = tickerRegistry;
+        this.config = config;
+    }
+
+    @Override
+    public String getDataProviderName() {
+        return "Hibachi";
+    }
+
+    @Override
+    public Date getServerTime() {
+        return restApi.getServerTime();
+    }
+
+    @Override
+    public boolean isConnected() {
+        return started && marketClient != null && marketClient.isOpen();
+    }
+
+    @Override
+    public void startEngine() {
+        if (started) {
+            return;
+        }
+        started = true;
+        ensureMarketClient();
+    }
+
+    @Override
+    public void startEngine(Properties props) {
+        startEngine();
+    }
+
+    @Override
+    public boolean started() {
+        return started;
+    }
+
+    @Override
+    public void stopEngine() {
+        started = false;
+        activeSubscriptions.clear();
+        HibachiWebSocketClient client = marketClient;
+        marketClient = null;
+        HibachiJsonProcessor processor = marketProcessor;
+        marketProcessor = null;
+        if (client != null) {
+            try { client.close(); } catch (Exception ignored) {}
+        }
+        if (processor != null) {
+            processor.shutdown();
+        }
+    }
+
+    @Override
+    public void subscribeLevel1(Ticker ticker, Level1QuoteListener listener) {
+        requireTicker(ticker);
+        super.subscribeLevel1(ticker, listener);
+        ensureMarketClient();
+        for (String topic : HibachiTopicRouter.LEVEL1_TOPICS) {
+            subscribeTopic(ticker, topic);
+        }
+    }
+
+    @Override
+    public void subscribeMarketDepth(Ticker ticker, Level2QuoteListener listener) {
+        requireTicker(ticker);
+        super.subscribeMarketDepth(ticker, listener);
+        ensureMarketClient();
+        subscribeTopic(ticker, HibachiTopicRouter.LEVEL2_TOPIC);
+    }
+
+    @Override
+    public void subscribeOrderFlow(Ticker ticker, OrderFlowListener listener) {
+        requireTicker(ticker);
+        super.subscribeOrderFlow(ticker, listener);
+        ensureMarketClient();
+        subscribeTopic(ticker, HibachiTopicRouter.ORDER_FLOW_TOPIC);
+    }
+
+    @Override
+    public ILevel1Quote requestLevel1Snapshot(Ticker ticker) {
+        requireTicker(ticker);
+        JsonNode response = restApi.getOrderBookSnapshot(ticker.getSymbol());
+        if (response == null || response.isMissingNode()) {
+            throw new IllegalStateException("No order-book snapshot for " + ticker.getSymbol());
+        }
+        Level1Quote quote = new Level1Quote(ticker, ZonedDateTime.now(UTC));
+        BigDecimal bid = topPrice(response, "bids");
+        BigDecimal ask = topPrice(response, "asks");
+        if (bid != null) quote.addQuote(QuoteType.BID, bid);
+        if (ask != null) quote.addQuote(QuoteType.ASK, ask);
+        return quote;
+    }
+
+    @Override
+    public void useDelayedData(boolean useDelayed) {
+        logger.debug("useDelayedData() not supported for Hibachi");
+    }
+
+    // ---------- WS plumbing ----------
+
+    protected synchronized void ensureMarketClient() {
+        if (marketClient != null && marketClient.isOpen()) {
+            return;
+        }
+        try {
+            marketProcessor = new HibachiJsonProcessor(this::onMarketWsClosed);
+            marketProcessor.addEventListener(this::onMarketMessage);
+            marketClient = HibachiWebSocketClient.createMarket(
+                    config.getMarketWsUrl(), marketProcessor, config.getClient(), null);
+            marketClient.connect();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to create Hibachi market WS client", e);
+        }
+    }
+
+    protected synchronized void subscribeTopic(Ticker ticker, String topic) {
+        SubKey key = new SubKey(ticker.getSymbol(), topic);
+        if (!activeSubscriptions.add(key)) {
+            return;
+        }
+        try {
+            String msg = HibachiMarketSubscribeMessage.subscribe(ticker.getSymbol(), topic);
+            if (marketClient != null && marketClient.isOpen()) {
+                marketClient.send(msg);
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to send subscribe for {} {}", ticker.getSymbol(), topic, e);
+        }
+    }
+
+    protected void onMarketWsClosed() {
+        if (!started) {
+            return;
+        }
+        logger.warn("Hibachi market WS closed; will not auto-reconnect in this engine version");
+    }
+
+    protected void onMarketMessage(JsonNode message) {
+        if (message == null) {
+            return;
+        }
+        String topic = message.path("topic").asText("");
+        String symbol = message.path("symbol").asText("");
+        if (topic.isEmpty()) {
+            return;
+        }
+        Ticker ticker = lookupTicker(symbol);
+        if (ticker == null) {
+            return;
+        }
+        try {
+            switch (topic) {
+                case HibachiTopicRouter.TOPIC_ASK_BID_PRICE -> onAskBidUpdate(ticker, message);
+                case HibachiTopicRouter.TOPIC_MARK_PRICE -> onMarkPriceUpdate(ticker, message);
+                case HibachiTopicRouter.TOPIC_ORDERBOOK -> onOrderBookUpdate(ticker, message);
+                case HibachiTopicRouter.TOPIC_TRADES -> onTradesUpdate(ticker, message);
+                default -> { /* unhandled topic */ }
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to dispatch Hibachi market message for {} {}", symbol, topic, e);
+        }
+    }
+
+    protected void onAskBidUpdate(Ticker ticker, JsonNode message) {
+        Level1Quote quote = new Level1Quote(ticker, toTimestamp(message, "timestamp"));
+        boolean any = false;
+        BigDecimal bid = decimal(message, "bidPrice");
+        if (bid != null) { quote.addQuote(QuoteType.BID, bid); any = true; }
+        BigDecimal bidSize = decimal(message, "bidSize");
+        if (bidSize != null) { quote.addQuote(QuoteType.BID_SIZE, bidSize); any = true; }
+        BigDecimal ask = decimal(message, "askPrice");
+        if (ask != null) { quote.addQuote(QuoteType.ASK, ask); any = true; }
+        BigDecimal askSize = decimal(message, "askSize");
+        if (askSize != null) { quote.addQuote(QuoteType.ASK_SIZE, askSize); any = true; }
+        if (any) {
+            fireLevel1Quote(quote);
+        }
+    }
+
+    protected void onMarkPriceUpdate(Ticker ticker, JsonNode message) {
+        Level1Quote quote = new Level1Quote(ticker, toTimestamp(message, "timestamp"));
+        boolean any = false;
+        BigDecimal mark = firstDecimal(message, "markPrice", "price");
+        if (mark != null) { quote.addQuote(QuoteType.MARK_PRICE, mark); any = true; }
+        if (any) {
+            fireLevel1Quote(quote);
+        }
+    }
+
+    protected void onOrderBookUpdate(Ticker ticker, JsonNode message) {
+        List<OrderBook.PriceLevel> bids = parseLevels(message.path("bids"));
+        List<OrderBook.PriceLevel> asks = parseLevels(message.path("asks"));
+        if (bids.isEmpty() && asks.isEmpty()) {
+            return;
+        }
+        OrderBook orderBook = new OrderBook(ticker, ticker.getMinimumTickSize());
+        ZonedDateTime timestamp = toTimestamp(message, "timestamp");
+        orderBook.updateFromSnapshot(bids, asks, timestamp);
+        fireMarketDepthQuote(new Level2Quote(ticker, orderBook, timestamp));
+    }
+
+    protected void onTradesUpdate(Ticker ticker, JsonNode message) {
+        JsonNode trades = message.path("trades");
+        if (!trades.isArray()) {
+            // Single-trade payload?
+            emitTrade(ticker, message);
+            return;
+        }
+        for (JsonNode trade : trades) {
+            emitTrade(ticker, trade);
+        }
+    }
+
+    protected void emitTrade(Ticker ticker, JsonNode trade) {
+        BigDecimal price = decimal(trade, "price");
+        BigDecimal size = firstDecimal(trade, "quantity", "size");
+        if (price == null || size == null) {
+            return;
+        }
+        String sideStr = trade.path("side").asText("BID").toUpperCase();
+        OrderFlow.Side side = "ASK".equals(sideStr) || "SELL".equals(sideStr)
+                ? OrderFlow.Side.SELL : OrderFlow.Side.BUY;
+        OrderFlow flow = new OrderFlow(ticker, price, size, side, toTimestamp(trade, "timestamp"));
+        fireOrderFlow(flow);
+    }
+
+    protected Ticker lookupTicker(String symbol) {
+        if (symbol == null || symbol.isBlank()) {
+            return null;
+        }
+        Ticker t = tickerRegistry.lookupByBrokerSymbol(com.fueledbychai.data.InstrumentType.PERPETUAL_FUTURES, symbol);
+        if (t == null) {
+            t = tickerRegistry.lookupByCommonSymbol(com.fueledbychai.data.InstrumentType.PERPETUAL_FUTURES, symbol);
+        }
+        return t;
+    }
+
+    protected BigDecimal topPrice(JsonNode root, String side) {
+        JsonNode levels = root.path(side);
+        if (!levels.isArray() || levels.size() == 0) {
+            return null;
+        }
+        JsonNode first = levels.get(0);
+        if (!first.isArray() || first.size() == 0) {
+            return null;
+        }
+        try {
+            return new BigDecimal(first.get(0).asText());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    protected List<OrderBook.PriceLevel> parseLevels(JsonNode arr) {
+        List<OrderBook.PriceLevel> out = new ArrayList<>();
+        if (arr == null || !arr.isArray()) {
+            return out;
+        }
+        for (JsonNode lvl : arr) {
+            if (!lvl.isArray() || lvl.size() < 2) continue;
+            try {
+                BigDecimal price = new BigDecimal(lvl.get(0).asText());
+                double size = Double.parseDouble(lvl.get(1).asText());
+                out.add(new OrderBook.PriceLevel(price, size));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return out;
+    }
+
+    protected ZonedDateTime toTimestamp(JsonNode message, String field) {
+        if (message == null) {
+            return ZonedDateTime.now(UTC);
+        }
+        long epoch = message.path(field).asLong(0L);
+        if (epoch <= 0L) {
+            return ZonedDateTime.now(UTC);
+        }
+        // Heuristic: values < 1e12 are seconds, else millis.
+        long millis = epoch < 1_000_000_000_000L ? epoch * 1000L : epoch;
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), UTC);
+    }
+
+    protected BigDecimal decimal(JsonNode message, String field) {
+        if (message == null) return null;
+        String raw = message.path(field).asText("");
+        if (raw.isBlank()) return null;
+        try {
+            return new BigDecimal(raw);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    protected BigDecimal firstDecimal(JsonNode message, String... fields) {
+        for (String f : fields) {
+            BigDecimal v = decimal(message, f);
+            if (v != null) {
+                return v;
+            }
+        }
+        return null;
+    }
+
+    protected void requireTicker(Ticker ticker) {
+        if (ticker == null) {
+            throw new IllegalArgumentException("ticker is required");
+        }
+    }
+
+    private static final class SubKey {
+        final String symbol;
+        final String topic;
+
+        SubKey(String symbol, String topic) {
+            this.symbol = symbol;
+            this.topic = topic;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof SubKey)) return false;
+            SubKey k = (SubKey) o;
+            return symbol.equals(k.symbol) && topic.equals(k.topic);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * symbol.hashCode() + topic.hashCode();
+        }
+    }
+
+    // unused but kept for spi clarity
+    @SuppressWarnings("unused")
+    private static final Set<String> SUPPORTED_TOPICS = Set.copyOf(new HashSet<>(List.of(
+            HibachiTopicRouter.TOPIC_ASK_BID_PRICE,
+            HibachiTopicRouter.TOPIC_MARK_PRICE,
+            HibachiTopicRouter.TOPIC_ORDERBOOK,
+            HibachiTopicRouter.TOPIC_TRADES)));
+}

--- a/implementations/market-data-api/hibachi-market-data-impl/src/main/java/com/fueledbychai/marketdata/hibachi/HibachiQuoteEngineProvider.java
+++ b/implementations/market-data-api/hibachi-market-data-impl/src/main/java/com/fueledbychai/marketdata/hibachi/HibachiQuoteEngineProvider.java
@@ -1,0 +1,18 @@
+package com.fueledbychai.marketdata.hibachi;
+
+import com.fueledbychai.data.Exchange;
+import com.fueledbychai.marketdata.QuoteEngine;
+import com.fueledbychai.marketdata.QuoteEngineProvider;
+
+public class HibachiQuoteEngineProvider implements QuoteEngineProvider {
+
+    @Override
+    public Exchange getExchange() {
+        return Exchange.HIBACHI;
+    }
+
+    @Override
+    public Class<? extends QuoteEngine> getQuoteEngineClass() {
+        return HibachiQuoteEngine.class;
+    }
+}

--- a/implementations/market-data-api/hibachi-market-data-impl/src/main/resources/META-INF/services/com.fueledbychai.marketdata.QuoteEngineProvider
+++ b/implementations/market-data-api/hibachi-market-data-impl/src/main/resources/META-INF/services/com.fueledbychai.marketdata.QuoteEngineProvider
@@ -1,0 +1,1 @@
+com.fueledbychai.marketdata.hibachi.HibachiQuoteEngineProvider

--- a/implementations/market-data-api/pom.xml
+++ b/implementations/market-data-api/pom.xml
@@ -58,6 +58,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     <module>bybit-market-data-impl</module>
     <module>aster-market-data-impl</module>
     <module>drift-market-data-impl</module>
+    <module>hibachi-market-data-impl</module>
   </modules>
   
 </project>


### PR DESCRIPTION
Subscribes to Hibachi L1 (ask_bid_price + mark_price), L2 (orderbook), and OrderFlow (trades) for a single perp. Wires hibachi-market-data-impl and hibachi-broker-api-impl into the CryptoExamples reactor module so the SPI providers are on the classpath at runtime.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Description

Brief description of changes made

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Broker Impact

- [ ] Interactive Brokers
- [ ] Paradex
- [ ] Hyperliquid
- [ ] Paper Broker
- [ ] Core API
- [ ] No broker impact

## Testing

- [ ] Unit tests pass (`mvn test`)
- [ ] Integration tests pass (`mvn verify`)
- [ ] Manual testing completed
- [ ] New tests added for new functionality

## Documentation

- [ ] Code comments updated
- [ ] README updated (if applicable)
- [ ] CHANGELOG.md updated
- [ ] API documentation updated (if applicable)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
